### PR TITLE
Fixing issue when using Assume Role in conjunction with EFO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@ under the License.
 		<aws.kinesis-kcl.version>1.14.0</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
+		<httpclient.version>4.5.9</httpclient.version>
+		<httpcore.version>4.4.11</httpcore.version>
 	</properties>
 
 	<scm>
@@ -193,6 +195,17 @@ under the License.
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>sts</artifactId>
 			<version>${aws.sdkv2.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${httpcore.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/META-INF/services/software.amazon.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
+++ b/src/main/resources/META-INF/services/software.amazon.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
@@ -1,20 +1,17 @@
 #
-# This file has been modified from the original.
+#   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#       http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 
 software.amazon.kinesis.shaded.software.amazon.awssdk.http.apache.ApacheSdkHttpService

--- a/src/main/resources/META-INF/services/software.amazon.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
+++ b/src/main/resources/META-INF/services/software.amazon.kinesis.shaded.software.amazon.awssdk.http.SdkHttpService
@@ -1,0 +1,20 @@
+#
+# This file has been modified from the original.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+software.amazon.kinesis.shaded.software.amazon.awssdk.http.apache.ApacheSdkHttpService


### PR DESCRIPTION
*Issue*
Assume role credential provider requires a synchronous HTTP client to make additional calls to IAM. Usually this would be automatically created from the classpath, however due to relocation shading service descriptors are wrong. 

*Description of changes:*
- Added service description for shaded Apache HTTP client
- Updated HTTP client and core dependencies versions to resolve compatibility issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
