### PR TITLE
Enable Jacoco report for Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,38 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>${surefireArgLine} -Xmx2048m</argLine>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<!-- attached to Maven test phase -->
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<destFile>${sonar.jacoco.reportPath}</destFile>
+					<!-- Sets the VM argument line used when unit tests are run. -->
+					<propertyName>surefireArgLine</propertyName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
@@ -22,10 +22,7 @@ package software.amazon.kinesis.connectors.flink.proxy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerRequest;
@@ -57,8 +54,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test for methods in the {@link KinesisProxyV2} class.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(KinesisProxyV2.class)
 public class KinesisProxyV2Test {
 
 	private static final long EXPECTED_SUBSCRIBE_TO_SHARD_MAX = 1;


### PR DESCRIPTION
*Description of changes:*
- Enabled Jacoco coverage report to run on maven build
- Removed unused Powermock runner from `KinesisProxyV2Test`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
