### PR TITLE
Ignore ReadTimeoutException from SubcribeToShard retry policy

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -150,12 +150,16 @@ public class FanOutRecordPublisher implements RecordPublisher {
 				return RecordPublisherRunResult.COMPLETE;
 			}
 
-			if (attempt == configuration.getSubscribeToShardMaxRetries()) {
-				throw new RuntimeException("Maximum reties exceeded for SubscribeToShard. " +
-					"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.");
+			if (!(ex.getCause() instanceof io.netty.handler.timeout.ReadTimeoutException)) {
+				if (attempt == configuration.getSubscribeToShardMaxRetries()) {
+					final String errorMessage = "Maximum reties exceeded for SubscribeToShard. " +
+							"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.";
+					LOG.error(errorMessage, ex.getCause());
+					throw new RuntimeException(errorMessage, ex.getCause());
+				}
+				attempt++;
 			}
 
-			attempt++;
 			backoff(ex);
 			return RecordPublisherRunResult.INCOMPLETE;
 		}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordBatch;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutShardSubscriber.FanOutSubscriberException;
+import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutShardSubscriber.RecoverableFanOutSubscriberException;
 import software.amazon.kinesis.connectors.flink.model.SequenceNumber;
 import software.amazon.kinesis.connectors.flink.model.StartingPosition;
 import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
@@ -137,8 +138,13 @@ public class FanOutRecordPublisher implements RecordPublisher {
 
 		try {
 			complete = fanOutShardSubscriber.subscribeToShardAndConsumeRecords(
-				toSdkV2StartingPosition(nextStartingPosition), eventConsumer);
+					toSdkV2StartingPosition(nextStartingPosition), eventConsumer);
 			attempt = 0;
+		} catch (RecoverableFanOutSubscriberException ex) {
+			// Recoverable errors should be reattempted without contributing to the retry policy
+			// A recoverable error would not result in the Flink job being cancelled
+			backoff(ex);
+			return RecordPublisherRunResult.INCOMPLETE;
 		} catch (FanOutSubscriberException ex) {
 			// We have received an error from the network layer
 			// This can be due to limits being exceeded, network timeouts, etc
@@ -150,16 +156,14 @@ public class FanOutRecordPublisher implements RecordPublisher {
 				return RecordPublisherRunResult.COMPLETE;
 			}
 
-			if (!(ex.getCause() instanceof io.netty.handler.timeout.ReadTimeoutException)) {
-				if (attempt == configuration.getSubscribeToShardMaxRetries()) {
-					final String errorMessage = "Maximum reties exceeded for SubscribeToShard. " +
-							"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.";
-					LOG.error(errorMessage, ex.getCause());
-					throw new RuntimeException(errorMessage, ex.getCause());
-				}
-				attempt++;
+			if (attempt == configuration.getSubscribeToShardMaxRetries()) {
+				final String errorMessage = "Maximum reties exceeded for SubscribeToShard. " +
+						"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.";
+				LOG.error(errorMessage, ex.getCause());
+				throw new RuntimeException(errorMessage, ex.getCause());
 			}
 
+			attempt++;
 			backoff(ex);
 			return RecordPublisherRunResult.INCOMPLETE;
 		}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -217,6 +217,10 @@ public class FanOutShardSubscriber {
 			throwable.getClass().getName(), throwable.getMessage(), shardId, consumerArn, cause);
 
 		if (cause instanceof ReadTimeoutException) {
+			// ReadTimeoutException occurs naturally under backpressure scenarios when full batches take longer to
+			// process than standard read timeout (default 30s). Recoverable exceptions are intended to be retried
+			// indefinitely to avoid system degradation under backpressure. The EFO connection (subscription) to Kinesis
+			// is closed, and reacquired once the queue of records has been processed.
 			throw new RecoverableFanOutSubscriberException(cause);
 		} else {
 			throw new RetryableFanOutSubscriberException(cause);

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.internals.publisher.fanout;
+
+import io.netty.handler.timeout.ReadTimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.services.kinesis.model.StartingPosition;
+import software.amazon.kinesis.connectors.flink.testutils.FakeKinesisFanOutBehavioursFactory;
+import software.amazon.kinesis.connectors.flink.testutils.FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2;
+
+/**
+ * Tests for {@link FanOutShardSubscriber}.
+ */
+public class FanOutShardSubscriberTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testRecoverableErrorThrownToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
+		thrown.expectMessage("io.netty.handler.timeout.ReadTimeoutException");
+
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(ReadTimeoutException.INSTANCE);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testRetryableErrorThrownToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expectMessage("Error!");
+
+		RuntimeException error = new RuntimeException("Error!");
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+}

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -27,5 +27,6 @@ under the License.
 <suppressions>
 	<!-- Kinesis producer has to use guava directly -->
 	<suppress files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java" checks="IllegalImport"/>
-	<suppress files="FanOutRecordPublisher.java|FanOutRecordPublisherTest.java" checks="IllegalImport"/>
+	<suppress files="FanOutRecordPublisherTest.java" checks="IllegalImport"/>
+	<suppress files="FanOutShardSubscriber.java|FanOutShardSubscriberTest.java" checks="IllegalImport"/>
 </suppressions>

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -25,7 +25,7 @@ under the License.
 		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-		<!-- Kinesis producer has to use guava directly -->
-		<suppress
-			files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java" checks="IllegalImport"/>
+	<!-- Kinesis producer has to use guava directly -->
+	<suppress files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java" checks="IllegalImport"/>
+	<suppress files="FanOutRecordPublisher.java|FanOutRecordPublisherTest.java" checks="IllegalImport"/>
 </suppressions>


### PR DESCRIPTION
*Description of changes:*
- `ReadTimeoutException` ignored from retry policy. This allows client to fail and recover from errors thrown in high backpressure without causing the application to restart with retry policy. The Netty async client throws a `ReadTimeoutException` after 30s, meaning if >30s of backpressure is applied this exception will be thrown. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
