### PR TITLE
Optimise error handling to use a separate exception delivery mechanism

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -330,7 +330,11 @@ public class FanOutShardSubscriber {
 			// Cancel the subscription to signal the onNext to stop requesting data
 			cancelSubscription();
 
-			subscriptionErrorEvent.set(new SubscriptionErrorEvent(throwable));
+			if (subscriptionErrorEvent.get() == null) {
+				subscriptionErrorEvent.set(new SubscriptionErrorEvent(throwable));
+			} else {
+				LOG.warn("Previous error passed to consumer for processing. Ignoring subsequent exception.", throwable);
+			}
 		}
 
 		@Override

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -95,10 +95,9 @@ public class FanOutShardSubscriber {
 	 */
 	private static final int DEQUEUE_WAIT_SECONDS = 35;
 
-	/** The time to wait when enqueuing events to allow error events to "push in front" of data . */
-	private static final int ENQUEUE_WAIT_SECONDS = 5;
-
 	private final BlockingQueue<FanOutSubscriptionEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
+
+	private final AtomicReference<FanOutSubscriptionEvent> subscriptionErrorEvent = new AtomicReference<>();
 
 	private final KinesisProxyV2Interface kinesis;
 
@@ -246,8 +245,13 @@ public class FanOutShardSubscriber {
 		String continuationSequenceNumber;
 
 		do {
-			// Read timeout will occur after 30 seconds, add a sanity timeout here to prevent lockup
-			FanOutSubscriptionEvent subscriptionEvent = queue.poll(DEQUEUE_WAIT_SECONDS, SECONDS);
+			FanOutSubscriptionEvent subscriptionEvent;
+			if (queue.isEmpty() && subscriptionErrorEvent.get() != null) {
+				subscriptionEvent = subscriptionErrorEvent.get();
+			} else {
+				// Read timeout will occur after 30 seconds, add a sanity timeout here to prevent lockup
+				subscriptionEvent = queue.poll(DEQUEUE_WAIT_SECONDS, SECONDS);
+			}
 
 			if (subscriptionEvent == null) {
 				LOG.debug("Timed out polling events from network, reacquiring subscription - {} ({})", shardId, consumerArn);
@@ -259,6 +263,10 @@ public class FanOutShardSubscriber {
 					eventConsumer.accept(event);
 				}
 			} else if (subscriptionEvent.isSubscriptionComplete()) {
+				if (subscriptionErrorEvent.get() != null) {
+					handleError(subscriptionErrorEvent.get().getThrowable());
+				}
+
 				// The subscription is complete, but the shard might not be, so we return incomplete
 				return false;
 			} else {
@@ -282,8 +290,6 @@ public class FanOutShardSubscriber {
 		private volatile boolean cancelled = false;
 
 		private final CountDownLatch waitForSubscriptionLatch;
-
-		private final Object lockObject = new Object();
 
 		private FanOutShardSubscription(final CountDownLatch waitForSubscriptionLatch) {
 			this.waitForSubscriptionLatch = waitForSubscriptionLatch;
@@ -310,11 +316,8 @@ public class FanOutShardSubscriber {
 			subscribeToShardEventStream.accept(new SubscribeToShardResponseHandler.Visitor() {
 				@Override
 				public void visit(SubscribeToShardEvent event) {
-					synchronized (lockObject) {
-						if (enqueueEventWithRetry(new SubscriptionNextEvent(event))) {
-							requestRecord();
-						}
-					}
+					enqueueEvent(new SubscriptionNextEvent(event));
+					requestRecord();
 				}
 			});
 		}
@@ -324,15 +327,10 @@ public class FanOutShardSubscriber {
 			LOG.debug("Error occurred on EFO subscription: {} - ({}).  {} ({})",
 				throwable.getClass().getName(), throwable.getMessage(), shardId, consumerArn, throwable);
 
-			// Cancel the subscription to signal the onNext to stop queuing and requesting data
+			// Cancel the subscription to signal the onNext to stop requesting data
 			cancelSubscription();
 
-			synchronized (lockObject) {
-				// Empty the queue and add a poison pill to terminate this subscriber
-				// The synchronized block ensures that new data is not written in the meantime
-				queue.clear();
-				enqueueEvent(new SubscriptionErrorEvent(throwable));
-			}
+			subscriptionErrorEvent.set(new SubscriptionErrorEvent(throwable));
 		}
 
 		@Override
@@ -349,47 +347,17 @@ public class FanOutShardSubscriber {
 		}
 
 		/**
-		 * Continuously attempt to enqueue an event until successful or the subscription is cancelled (due to error).
-		 * When backpressure applied by the consumer exceeds 30s for a single batch, a ReadTimeoutException will be
-		 * thrown by the network stack. This will result in the subscription be cancelled and this event being discarded.
-		 * The subscription would subsequently be reacquired and the discarded data would be fetched again.
+		 * Adds the event to the queue blocking until complete.
 		 *
 		 * @param event the event to enqueue
-		 * @return true if the event was successfully enqueued.
 		 */
-		private boolean enqueueEventWithRetry(final FanOutSubscriptionEvent event) {
-			boolean result = false;
-			do {
-				if (cancelled) {
-					break;
-				}
-
-				synchronized (lockObject) {
-					result = enqueueEvent(event);
-				}
-			} while (!result);
-
-			return result;
-		}
-
-		/**
-		 * Offers the event to the queue.
-		 *
-		 * @param event the event to enqueue
-		 * @return true if the event was successfully enqueued.
-		 */
-		private boolean enqueueEvent(final FanOutSubscriptionEvent event) {
+		private void enqueueEvent(final FanOutSubscriptionEvent event) {
 			try {
-				if (!queue.offer(event, ENQUEUE_WAIT_SECONDS, SECONDS)) {
-					LOG.debug("Timed out enqueuing event {} - {} ({})", event.getClass().getSimpleName(), shardId, consumerArn);
-					return false;
-				}
+				queue.put(event);
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				throw new RuntimeException(e);
 			}
-
-			return true;
 		}
 	}
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -59,4 +59,19 @@ public class FanOutShardSubscriberTest {
 		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
 	}
 
+	@Test
+	public void testMultipleErrorsThrownPassesFirstErrorToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.FanOutSubscriberException.class);
+		thrown.expectMessage("Error 1!");
+
+		RuntimeException error1 = new RuntimeException("Error 1!");
+		RuntimeException error2 = new RuntimeException("Error 2!");
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error1, error2);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -87,8 +87,8 @@ public class FakeKinesisFanOutBehavioursFactory {
 		return new ExceptionalKinesisV2(ResourceNotFoundException.builder().build());
 	}
 
-	public static SubscriptionErrorKinesisV2 errorDuringSubscription(final Throwable throwable) {
-		return new SubscriptionErrorKinesisV2(throwable);
+	public static SubscriptionErrorKinesisV2 errorDuringSubscription(final Throwable...throwables) {
+		return new SubscriptionErrorKinesisV2(throwables);
 	}
 
 	public static SubscriptionErrorKinesisV2 alternatingSuccessErrorDuringSubscription() {
@@ -180,19 +180,21 @@ public class FakeKinesisFanOutBehavioursFactory {
 
 		public static final int NUMBER_OF_EVENTS_PER_SUBSCRIPTION = 5;
 
-		private final Throwable throwable;
+		private final Throwable[] throwables;
 
 		AtomicInteger sequenceNumber = new AtomicInteger();
 
-		private SubscriptionErrorKinesisV2(final Throwable throwable) {
+		private SubscriptionErrorKinesisV2(final Throwable...throwables) {
 			super(NUMBER_OF_SUBSCRIPTIONS);
-			this.throwable = throwable;
+			this.throwables = throwables;
 		}
 
 		@Override
 		void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
 			sendEventBatch(subscriber);
-			subscriber.onError(throwable);
+			for (Throwable throwable : throwables) {
+				subscriber.onError(throwable);
+			}
 		}
 
 		void sendEventBatch(Subscriber<? super SubscribeToShardEventStream> subscriber) {


### PR DESCRIPTION
*Description of changes:*
- There is a queue used to pass events between the network client and consumer application. When an error is thrown in the network thread, the queue is cleared to make space for the error event. This means that records will be thrown away to make space for errors (the records would be subsequently reloaded from the shard). 
- This change adds a new mechanism to pass exceptions between threads, meaning data does not need to be discarded. When an error is thrown, the error event will be processed by the consumer once all of the records have been processed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
