### PR TITLE
Fix issue when Polling consumer using timestamp with empty shard

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
@@ -50,7 +50,7 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
 
-	private static final SequenceNumber TIMESTAMP_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
+	private static final SequenceNumber TIMESTAMP_SENTINEL_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
 
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
@@ -125,7 +125,7 @@ public class PollingRecordPublisher implements RecordPublisher {
 		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
 		// This is because we have not yet received any real sequence numbers on this shard.
 		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
-		if (TIMESTAMP_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
+		if (TIMESTAMP_SENTINEL_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
 			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
 			return nextStartingPosition;
 		} else {

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
@@ -36,8 +36,10 @@ import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyInterface;
 
 import javax.annotation.Nullable;
 
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 
 /**
  * A {@link RecordPublisher} that will read records from Kinesis and forward them to the subscriber.
@@ -108,11 +110,25 @@ public class PollingRecordPublisher implements RecordPublisher {
 		GetRecordsResult result = getRecords(nextShardItr, maxNumberOfRecords);
 
 		RecordBatch recordBatch = new RecordBatch(result.getRecords(), subscribedShard, result.getMillisBehindLatest());
-		SequenceNumber latestSeequenceNumber = consumer.accept(recordBatch);
 
-		nextStartingPosition = StartingPosition.continueFromSequenceNumber(latestSeequenceNumber);
+		SequenceNumber latestSequenceNumber = consumer.accept(recordBatch);
+
+		nextStartingPosition = getNextStartingPosition(latestSequenceNumber);
 		nextShardItr = result.getNextShardIterator();
 		return nextShardItr == null ? COMPLETE : INCOMPLETE;
+	}
+
+	private StartingPosition getNextStartingPosition(final SequenceNumber latestSequenceNumber) {
+		// When consuming from a timestamp sentinel/AT_TIMESTAMP ShardIteratorType.
+		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
+		// This is because we have not yet received any real sequence numbers on this shard.
+		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
+		if (SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().equals(latestSequenceNumber)) {
+			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
+			return nextStartingPosition;
+		}
+
+		return StartingPosition.continueFromSequenceNumber(latestSequenceNumber);
 	}
 
 	/**

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
@@ -50,6 +50,8 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
 
+	private static final SequenceNumber TIMESTAMP_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
+
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
 	private final KinesisProxyInterface kinesisProxy;
@@ -123,12 +125,12 @@ public class PollingRecordPublisher implements RecordPublisher {
 		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
 		// This is because we have not yet received any real sequence numbers on this shard.
 		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
-		if (SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().equals(latestSequenceNumber)) {
+		if (TIMESTAMP_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
 			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
 			return nextStartingPosition;
+		} else {
+			return StartingPosition.continueFromSequenceNumber(latestSequenceNumber);
 		}
-
-		return StartingPosition.continueFromSequenceNumber(latestSequenceNumber);
 	}
 
 	/**

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisBehavioursFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisBehavioursFactory.java
@@ -86,6 +86,10 @@ public class FakeKinesisBehavioursFactory {
 	//  Behaviours related to fetching records, used mainly in ShardConsumerTest
 	// ------------------------------------------------------------------------
 
+	public static KinesisProxyInterface emptyShard(final int numberOfIterations) {
+		return new SingleShardEmittingZeroRecords(numberOfIterations);
+	}
+
 	public static KinesisProxyInterface totalNumOfRecordsAfterNumOfGetRecordsCalls(
 		final int numOfRecords,
 		final int numOfGetRecordsCalls,
@@ -131,6 +135,32 @@ public class FakeKinesisBehavioursFactory {
 
 	public static KinesisProxyInterface blockingQueueGetRecords(Map<String, List<BlockingQueue<String>>> streamsToShardQueues) {
 		return new BlockingQueueKinesis(streamsToShardQueues);
+	}
+
+	private static class SingleShardEmittingZeroRecords implements KinesisProxyInterface {
+
+		private int remainingIterators;
+
+		private SingleShardEmittingZeroRecords(int remainingIterators) {
+			this.remainingIterators = remainingIterators;
+		}
+
+		@Override
+		public String getShardIterator(StreamShardHandle shard, String shardIteratorType, Object startingMarker) throws InterruptedException {
+			return String.valueOf(remainingIterators--);
+		}
+
+		@Override
+		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) throws InterruptedException {
+			return new GetRecordsResult()
+					.withMillisBehindLatest(0L)
+					.withNextShardIterator(remainingIterators == 0 ? null : String.valueOf(remainingIterators--));
+		}
+
+		@Override
+		public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds) throws InterruptedException {
+			return null;
+		}
 	}
 
 	private static class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis extends SingleShardEmittingFixNumOfRecordsKinesis {


### PR DESCRIPTION
*Description of changes:*
The consumer fails when a Polling record publisher uses a timestamp sentinel starting position and the first record batch is empty. This is because the consumer tries to recalculate the start position from the timestamp sentinel, this operation is not supported.

This is fixed by reusing the existing timestamp starting position in this condition.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
