### PR TITLE
Backport code from Flink release-1.12.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release 2.0.0 (December 11th, 2020)
+* Fix issue when Polling consumer using timestamp with empty shard
+  ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/6))
+
 ## Release 1.0.4 (November 11th, 2020)
 * Fix issue when Polling consumer using timestamp with empty shard
   ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/6))

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Amazon Kinesis Connector for Apache Flink
 
-This is a fork of the official Apache Flink Kinesis Connector:
-- https://github.com/apache/flink/tree/master/flink-connectors/flink-connector-kinesis
+This is a fork of [the official Apache Flink Kinesis Connector](https://github.com/apache/flink/tree/master/flink-connectors/flink-connector-kinesis).
 
-This connector library adds Enhanced Fanout (EFO) support for Flink 1.8/1.11, allowing you to utilise EFO on Kinesis Data Analytics (KDA).
-EFO is already available in the official Apache Flink connector for Flink 1.12.   
-- https://issues.apache.org/jira/browse/FLINK-17688
-- https://cwiki.apache.org/confluence/display/FLINK/FLIP-128%3A+Enhanced+Fan+Out+for+AWS+Kinesis+Consumers
+The fork backports the following features to older versions of Flink:
+
+  - Enhanced Fanout (EFO) support for Flink 1.8/1.11. For the original contributions see:
+    - [FLIP-128: Enhanced Fan Out for AWS Kinesis Consumers](https://cwiki.apache.org/confluence/display/FLINK/FLIP-128%3A+Enhanced+Fan+Out+for+AWS+Kinesis+Consumers)
+    - [FLINK-17688: Support consuming Kinesis' enhanced fanout for flink-connector-kinesis](https://issues.apache.org/jira/browse/FLINK-17688)
+  - Support for KDS data sources and sinks in Table API and SQL for Flink 1.11. For the original contributions see:
+    - [FLINK-18858: Kinesis Flink SQL Connector](https://issues.apache.org/jira/browse/FLINK-18858)
+
+Both features are already available in the official Apache Flink connector for Flink 1.12.
 
 ## Quickstart 
 
@@ -17,12 +21,16 @@ Add the following dependency to your project to start using the connector.
 <dependency>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-connector-flink</artifactId>
-    <version>1.0.4</version>
+    <version>2.0.0</version>
 </dependency>
 ```  
 
 Refer to the official Apache Flink documentation for more information on configuring the connector:
-- https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/kinesis.html 
+- [Amazon Kinesis Data Streams Connector](https://ci.apache.org/projects/flink/flink-docs-master/dev/connectors/kinesis.html)
+- [Amazon Kinesis Data Streams SQL Connector](https://ci.apache.org/projects/flink/flink-docs-master/dev/table/connectors/kinesis.html)
+
+Note that Flink 1.11 does not support [the "Available Metadata" functionality from upstream Table/SQL connector documentation](https://ci.apache.org/projects/flink/flink-docs-master/dev/table/connectors/kinesis.html#available-metadata). 
+If you want to expose KDS metadata fields in your table definitions, consider upgrading to Flink 1.12 or higher and using the KDS connector from the upstream repository.
 
 ## Migration
 
@@ -33,21 +41,20 @@ If you are migrating from the Apache Flink Kinesis Connector, you should perform
       1. From: `org.apache.flink.streaming.connectors.kinesis`
       1. To: `software.amazon.kinesis.connectors.flink`
     
-For example:
-  
-  - `FlinkKinesisConsumer`
-      - From: `com.amazonaws.services.kinesisanalytics.flink.connectors.FlinkKinesisConsumer`
-      - To: `software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer`
+For example
+ 
+  - `com.amazonaws.services.kinesisanalytics.flink.connectors.FlinkKinesisConsumer` becomes
+  - `software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer`.
 
 ## Flink Versions
 
-This connector is supported for Flink 1.8 and Flink 1.11. 
+This connector is compatible with Flink 1.11.
+For a version of this connector that is compatible with Flink 1.8, see [the `release-1.0` branch](https://github.com/awslabs/amazon-kinesis-connector-flink/tree/release-1.0).
 Other versions of Flink may work, but are not officially supported. 
 
 ## Support
 
-We will support this connector until end of Q1 2021, 
-or until KDA supports an Apache Flink Kinesis connector with EFO support, whichever is later. 
+We will support this connector until end of Q1 2021, or until KDA supports an Apache Flink Kinesis connector with EFO support, whichever is later. 
 Beyond this, we will not maintain patching or security for this repo.
 The Apache Flink Kinesis connector should be used instead of this library once KDA supports an EFO enabled version.
 
@@ -99,8 +106,7 @@ Note the additional IAM permissions required to use EFO:
 }
 ```
 
-Refer to the offical Apache Flink development documentation for more information:
-- https://ci.apache.org/projects/flink/flink-docs-master/dev/connectors/kinesis.html 
+For more information refer to [the official EFO documentation for the KDS connector](https://ci.apache.org/projects/flink/flink-docs-master/dev/connectors/kinesis.html#using-enhanced-fan-out).
 
 ## Security
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.8.2</version>
+		<version>1.11.2</version>
 		<relativePath/>
 	</parent>
 
 	<groupId>software.amazon.kinesis</groupId>
 	<artifactId>amazon-kinesis-connector-flink</artifactId>
-	<version>1.1.0-RC1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>Amazon Kinesis Connector for Apache Flink</name>
 
 	<properties>
@@ -68,6 +68,8 @@ under the License.
 
 	<dependencies>
 
+		<!-- For the DataStream KDS connector -->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
@@ -81,6 +83,24 @@ under the License.
 			<version>${guava.version}</version>
 		</dependency>
 
+		<!-- For the SQL/Table KDS connector -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Test dependencies -->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
@@ -91,7 +111,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<artifactId>flink-tests</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
@@ -117,6 +137,21 @@ under the License.
 			<artifactId>flink-core</artifactId>
 			<version>${project.parent.version}</version>
 			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.parent.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/FixedKinesisPartitioner.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/FixedKinesisPartitioner.java
@@ -1,0 +1,79 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+
+/**
+ * A partitioner ensuring that each internal Flink partition ends up in the same Kinesis partition.
+ *
+ * <p>This is achieved by using the index of the producer task as a {@code PartitionKey}.</p>
+ */
+@PublicEvolving
+public final class FixedKinesisPartitioner<T> extends KinesisPartitioner<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int indexOfThisSubtask = 0;
+
+	@Override
+	public void initialize(int indexOfThisSubtask, int numberOfParallelSubtasks) {
+		Preconditions.checkArgument(
+			indexOfThisSubtask >= 0,
+			"Id of this subtask cannot be negative.");
+		Preconditions.checkArgument(
+			numberOfParallelSubtasks > 0,
+			"Number of subtasks must be larger than 0.");
+
+		this.indexOfThisSubtask = indexOfThisSubtask;
+	}
+
+	@Override
+	public String getPartitionId(T record) {
+		return String.valueOf(indexOfThisSubtask);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Value semantics for equals and hashCode
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final FixedKinesisPartitioner<?> that = (FixedKinesisPartitioner<?>) o;
+		return Objects.equals(this.indexOfThisSubtask, that.indexOfThisSubtask);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			FixedKinesisPartitioner.class.hashCode(),
+			indexOfThisSubtask);
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisConsumer.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisConsumer.java
@@ -21,6 +21,7 @@ package software.amazon.kinesis.connectors.flink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.ListState;
@@ -41,6 +42,7 @@ import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
+import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.InitialPosition;
 import software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher;
 import software.amazon.kinesis.connectors.flink.model.KinesisStreamShardState;
 import software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber;
@@ -242,7 +244,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	 */
 	public void setShardAssigner(KinesisShardAssigner shardAssigner) {
 		this.shardAssigner = checkNotNull(shardAssigner, "function can not be null");
-		ClosureCleaner.clean(shardAssigner, true);
+		ClosureCleaner.clean(shardAssigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public AssignerWithPeriodicWatermarks<T> getPeriodicWatermarkAssigner() {
@@ -257,7 +259,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	public void setPeriodicWatermarkAssigner(
 		AssignerWithPeriodicWatermarks<T> periodicWatermarkAssigner) {
 		this.periodicWatermarkAssigner = periodicWatermarkAssigner;
-		ClosureCleaner.clean(this.periodicWatermarkAssigner, true);
+		ClosureCleaner.clean(this.periodicWatermarkAssigner, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	public WatermarkTracker getWatermarkTracker() {
@@ -271,7 +273,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	 */
 	public void setWatermarkTracker(WatermarkTracker watermarkTracker) {
 		this.watermarkTracker = watermarkTracker;
-		ClosureCleaner.clean(this.watermarkTracker, true);
+		ClosureCleaner.clean(this.watermarkTracker, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
 
 	// ------------------------------------------------------------------------
@@ -320,7 +322,7 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 			} else {
 				// we're starting fresh; use the configured start position as initial state
 				SentinelSequenceNumber startingSeqNum =
-					ConsumerConfigConstants.InitialPosition.valueOf(configProps.getProperty(
+					InitialPosition.valueOf(configProps.getProperty(
 						ConsumerConfigConstants.STREAM_INITIAL_POSITION,
 						ConsumerConfigConstants.DEFAULT_STREAM_INITIAL_POSITION)).toSentinelSequenceNumber();
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/KinesisPartitioner.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/KinesisPartitioner.java
@@ -35,14 +35,18 @@ public abstract class KinesisPartitioner<T> implements Serializable {
 
 	/**
 	 * Return a partition id based on the input.
+	 *
 	 * @param element Element to partition
+	 *
 	 * @return A string representing the partition id
 	 */
 	public abstract String getPartitionId(T element);
 
 	/**
 	 * Optional method for setting an explicit hash key.
+	 *
 	 * @param element Element to get the hash key for
+	 *
 	 * @return the hash key for the element
 	 */
 	public String getExplicitHashKey(T element) {

--- a/src/main/java/software/amazon/kinesis/connectors/flink/RandomKinesisPartitioner.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/RandomKinesisPartitioner.java
@@ -1,0 +1,49 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.UUID;
+
+/**
+ * A {@link KinesisPartitioner} that maps an arbitrary input {@code element} to a random partition
+ * ID.
+ *
+ * @param <T> The input element type.
+ */
+@PublicEvolving
+public final class RandomKinesisPartitioner<T> extends KinesisPartitioner<T> {
+	@Override
+	public String getPartitionId(T element) {
+		return UUID.randomUUID().toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return o instanceof RandomKinesisPartitioner;
+	}
+
+	@Override
+	public int hashCode() {
+		return RandomKinesisPartitioner.class.hashCode();
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/config/AWSConfigConstants.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/config/AWSConfigConstants.java
@@ -50,7 +50,10 @@ public class AWSConfigConstants {
 		/** Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied. **/
 		ASSUME_ROLE,
 
-		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, PROFILE in the AWS instance metadata. **/
+		/** Use AWS WebIdentityToken in order to assume a role. A token file and role details can be supplied as configuration or environment variables. **/
+		WEB_IDENTITY_TOKEN,
+
+		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, WEB_IDENTITY_TOKEN, PROFILE in the AWS instance metadata. **/
 		AUTO,
 	}
 
@@ -72,14 +75,17 @@ public class AWSConfigConstants {
 	/** Optional configuration for profile name if credential provider type is set to be PROFILE. */
 	public static final String AWS_PROFILE_NAME = profileName(AWS_CREDENTIALS_PROVIDER);
 
-	/** The role ARN to use when credential provider type is set to ASSUME_ROLE. */
+	/** The role ARN to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN. */
 	public static final String AWS_ROLE_ARN = roleArn(AWS_CREDENTIALS_PROVIDER);
 
-	/** The role session name to use when credential provider type is set to ASSUME_ROLE. */
+	/** The role session name to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN. */
 	public static final String AWS_ROLE_SESSION_NAME = roleSessionName(AWS_CREDENTIALS_PROVIDER);
 
 	/** The external ID to use when credential provider type is set to ASSUME_ROLE. */
 	public static final String AWS_ROLE_EXTERNAL_ID = externalId(AWS_CREDENTIALS_PROVIDER);
+
+	/** The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN. */
+	public static final String AWS_WEB_IDENTITY_TOKEN_FILE = webIdentityTokenFile(AWS_CREDENTIALS_PROVIDER);
 
 	/**
 	 * The credentials provider that provides credentials for assuming the role when credential
@@ -121,5 +127,9 @@ public class AWSConfigConstants {
 
 	public static String roleCredentialsProvider(String prefix) {
 		return prefix + ".role.provider";
+	}
+
+	public static String webIdentityTokenFile(String prefix) {
+		return prefix + ".webIdentityToken.file";
 	}
 }

--- a/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
@@ -26,6 +26,8 @@ import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
 import software.amazon.kinesis.connectors.flink.internals.ShardConsumer;
 import software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber;
 
+import java.time.Duration;
+
 /**
  * Optional consumer specific configuration keys and default values for {@link FlinkKinesisConsumer}.
  */
@@ -70,19 +72,18 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	}
 
 	/**
-	 * The EFO registration type reprsents how we are going to de-/register EFO consumer.
+	 * The EFO registration type reprsents how we are going to de-/register efo consumer.
 	 */
 	public enum EFORegistrationType {
 
-		/** Delay the registration of EFO consumer for task manager to execute.
-		 * De-register the EFO consumer for task manager to execute when task is shut down. */
+		/** Delay the registration of efo consumer for taskmanager to execute.
+		 * De-register the efo consumer for taskmanager to execute when task is shut down. */
 		LAZY,
-
-		/** Register the EFO consumer eagerly in job manager/client.
-		 * De-register the EFO consumer during task manager tear down. */
+		/** Register the efo consumer eagerly for jobmanager to execute.
+		 * De-register the efo consumer the same way as lazy does. */
 		EAGER,
-
-		/** Do not register or deregister EFO consumer. Application will supply ARN. */
+		/** Do not register efo consumer programmatically.
+		 * Do not de-register either. */
 		NONE
 	}
 
@@ -269,7 +270,7 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final int DEFAULT_REGISTER_STREAM_RETRIES = 10;
 
-	public static final long DEFAULT_REGISTER_STREAM_TIMEOUT_SECONDS = 60;
+	public static final Duration DEFAULT_REGISTER_STREAM_TIMEOUT = Duration.ofSeconds(60);
 
 	public static final long DEFAULT_REGISTER_STREAM_BACKOFF_BASE = 500L;
 
@@ -279,7 +280,7 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final int DEFAULT_DEREGISTER_STREAM_RETRIES = 10;
 
-	public static final long DEFAULT_DEREGISTER_STREAM_TIMEOUT_SECONDS = 60;
+	public static final Duration DEFAULT_DEREGISTER_STREAM_TIMEOUT = Duration.ofSeconds(60);
 
 	public static final long DEFAULT_DEREGISTER_STREAM_BACKOFF_BASE = 500L;
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcher.java
@@ -102,7 +102,8 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 		Integer subscribedShardStateIndex,
 		StreamShardHandle handle,
 		SequenceNumber lastSeqNum,
-		MetricGroup metricGroup) throws InterruptedException {
+		MetricGroup metricGroup,
+		KinesisDeserializationSchema<T> shardDeserializer) throws InterruptedException {
 
 		return new ShardConsumer<T>(
 			this,
@@ -110,6 +111,7 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 			subscribedShardStateIndex,
 			handle,
 			lastSeqNum,
-			new ShardConsumerMetricsReporter(metricGroup));
+			new ShardConsumerMetricsReporter(metricGroup),
+			shardDeserializer);
 	}
 }

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/AdaptivePollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/AdaptivePollingRecordPublisher.java
@@ -22,7 +22,6 @@ package software.amazon.kinesis.connectors.flink.internals.publisher.polling;
 import org.apache.flink.annotation.Internal;
 
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
-import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.metrics.PollingRecordPublisherMetricsReporter;
 import software.amazon.kinesis.connectors.flink.model.SequenceNumber;
 import software.amazon.kinesis.connectors.flink.model.StartingPosition;
@@ -66,8 +65,8 @@ public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
 	}
 
 	@Override
-	public RecordPublisher.RecordPublisherRunResult run(final RecordPublisher.RecordBatchConsumer consumer) throws InterruptedException {
-		final RecordPublisher.RecordPublisherRunResult result = super.run(batch -> {
+	public RecordPublisherRunResult run(final RecordBatchConsumer consumer) throws InterruptedException {
+		final RecordPublisherRunResult result = super.run(batch -> {
 			SequenceNumber latestSequenceNumber = consumer.accept(batch);
 			lastRecordBatchSize = batch.getDeaggregatedRecordSize();
 			lastRecordBatchSizeInBytes = batch.getTotalSizeInBytes();

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
@@ -50,8 +50,6 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
 
-	private static final SequenceNumber TIMESTAMP_SENTINEL_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
-
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
 	private final KinesisProxyInterface kinesisProxy;
@@ -112,7 +110,6 @@ public class PollingRecordPublisher implements RecordPublisher {
 		GetRecordsResult result = getRecords(nextShardItr, maxNumberOfRecords);
 
 		RecordBatch recordBatch = new RecordBatch(result.getRecords(), subscribedShard, result.getMillisBehindLatest());
-
 		SequenceNumber latestSequenceNumber = consumer.accept(recordBatch);
 
 		nextStartingPosition = getNextStartingPosition(latestSequenceNumber);
@@ -125,7 +122,7 @@ public class PollingRecordPublisher implements RecordPublisher {
 		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
 		// This is because we have not yet received any real sequence numbers on this shard.
 		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
-		if (TIMESTAMP_SENTINEL_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
+		if (SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().equals(latestSequenceNumber)) {
 			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
 			return nextStartingPosition;
 		} else {

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactory.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactory.java
@@ -23,7 +23,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.Preconditions;
 
-import software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher;
+import software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher.FlinkKinesisProxyFactory;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisherFactory;
 import software.amazon.kinesis.connectors.flink.metrics.PollingRecordPublisherMetricsReporter;
@@ -39,9 +39,9 @@ import java.util.Properties;
 @Internal
 public class PollingRecordPublisherFactory implements RecordPublisherFactory {
 
-	private final KinesisDataFetcher.FlinkKinesisProxyFactory kinesisProxyFactory;
+	private final FlinkKinesisProxyFactory kinesisProxyFactory;
 
-	public PollingRecordPublisherFactory(final KinesisDataFetcher.FlinkKinesisProxyFactory kinesisProxyFactory) {
+	public PollingRecordPublisherFactory(final FlinkKinesisProxyFactory kinesisProxyFactory) {
 		this.kinesisProxyFactory = kinesisProxyFactory;
 	}
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/model/StartingPosition.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/model/StartingPosition.java
@@ -32,6 +32,7 @@ import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_SEQUENCE
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.TRIM_HORIZON;
+import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.isSentinelSequenceNumber;
 
 /**
  * The position in which to start consuming from a stream.
@@ -86,7 +87,7 @@ public class StartingPosition {
 	}
 
 	private static StartingPosition fromSequenceNumber(final SequenceNumber sequenceNumber, final boolean restart) {
-		if (SentinelSequenceNumber.isSentinelSequenceNumber(sequenceNumber)) {
+		if (isSentinelSequenceNumber(sequenceNumber)) {
 			return new StartingPosition(fromSentinelSequenceNumber(sequenceNumber), null);
 		} else {
 			// we will be starting from an actual sequence number (due to restore from failure).

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/DynamoDBStreamsProxy.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/DynamoDBStreamsProxy.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.kinesis.connectors.flink.config.AWSConfigConstants;
 import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
 
 import javax.annotation.Nullable;
@@ -42,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static software.amazon.kinesis.connectors.flink.config.AWSConfigConstants.AWS_ENDPOINT;
+import static software.amazon.kinesis.connectors.flink.config.AWSConfigConstants.AWS_REGION;
 import static software.amazon.kinesis.connectors.flink.util.AWSUtil.getCredentialsProvider;
 import static software.amazon.kinesis.connectors.flink.util.AWSUtil.setAwsClientConfigProperties;
 
@@ -90,11 +91,11 @@ public class DynamoDBStreamsProxy extends KinesisProxy {
 		AmazonDynamoDBStreamsAdapterClient adapterClient =
 				new AmazonDynamoDBStreamsAdapterClient(credentials, awsClientConfig);
 
-		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {
-			adapterClient.setEndpoint(configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT));
+		if (configProps.containsKey(AWS_ENDPOINT)) {
+			adapterClient.setEndpoint(configProps.getProperty(AWS_ENDPOINT));
 		} else {
 			adapterClient.setRegion(Region.getRegion(
-					Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION))));
+					Regions.fromName(configProps.getProperty(AWS_REGION))));
 		}
 
 		return adapterClient;

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxy.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxy.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -213,8 +212,6 @@ public class KinesisProxy implements KinesisProxyInterface {
 	/**
 	 * Create the Kinesis client, using the provided configuration properties and default {@link ClientConfiguration}.
 	 * Derived classes can override this method to customize the client configuration.
-	 * @param configProps
-	 * @return
 	 */
 	protected AmazonKinesis createKinesisClient(Properties configProps) {
 
@@ -474,12 +471,7 @@ public class KinesisProxy implements KinesisProxyInterface {
 		// 	https://github.com/lyft/kinesalite/pull/4
 		if (startShardId != null && listShardsResults != null) {
 			List<Shard> shards = listShardsResults.getShards();
-			Iterator<Shard> shardItr = shards.iterator();
-			while (shardItr.hasNext()) {
-				if (StreamShardHandle.compareShardIds(shardItr.next().getShardId(), startShardId) <= 0) {
-					shardItr.remove();
-				}
-			}
+			shards.removeIf(shard -> StreamShardHandle.compareShardIds(shard.getShardId(), startShardId) <= 0);
 		}
 
 		return listShardsResults;

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2.java
@@ -20,6 +20,7 @@
 package software.amazon.kinesis.connectors.flink.proxy;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +74,7 @@ public class KinesisProxyV2 implements KinesisProxyV2Interface {
 			final SdkAsyncHttpClient httpClient,
 			final FanOutRecordPublisherConfiguration fanOutRecordPublisherConfiguration,
 			final FullJitterBackoff backoff) {
-		this.kinesisAsyncClient = kinesisAsyncClient;
+		this.kinesisAsyncClient = Preconditions.checkNotNull(kinesisAsyncClient);
 		this.httpClient = httpClient;
 		this.fanOutRecordPublisherConfiguration = fanOutRecordPublisherConfiguration;
 		this.backoff = backoff;

--- a/src/main/java/software/amazon/kinesis/connectors/flink/serialization/DynamoDBStreamsSchema.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/serialization/DynamoDBStreamsSchema.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.serialization;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import com.amazonaws.services.dynamodbv2.model.Record;
+import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.io.IOException;
  * Schema used for deserializing DynamoDB streams records.
  */
 public class DynamoDBStreamsSchema implements KinesisDeserializationSchema<Record> {
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final ObjectMapper MAPPER = new RecordObjectMapper();
 
 	@Override
 	public Record deserialize(byte[] message, String partitionKey, String seqNum,

--- a/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisDeserializationSchema.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisDeserializationSchema.java
@@ -37,6 +37,18 @@ import java.io.Serializable;
 public interface KinesisDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(DeserializationSchema.InitializationContext context) throws Exception {
+	}
+
+	/**
 	 * Deserializes a Kinesis record's bytes. If the record cannot be deserialized, {@code null}
 	 * may be returned. This informs the Flink Kinesis Consumer to process the Kinesis record
 	 * without producing any output for it, i.e. effectively "skipping" the record.

--- a/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisDeserializationSchemaWrapper.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.serialization;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
 
 import java.io.IOException;
 
@@ -37,7 +38,23 @@ public class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializ
 	private final DeserializationSchema<T> deserializationSchema;
 
 	public KinesisDeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {
+		try {
+			Class<? extends DeserializationSchema> deserilizationClass = deserializationSchema.getClass();
+			if (!deserilizationClass.getMethod("deserialize", byte[].class, Collector.class).isDefault()) {
+				throw new IllegalArgumentException(
+					"Kinesis consumer does not support DeserializationSchema that implements " +
+						"deserialization with a Collector. Unsupported DeserializationSchema: " +
+						deserilizationClass.getName());
+			}
+		} catch (NoSuchMethodException e) {
+			// swallow the exception
+		}
 		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		this.deserializationSchema.open(context);
 	}
 
 	@Override

--- a/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisSerializationSchema.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/serialization/KinesisSerializationSchema.java
@@ -20,6 +20,7 @@
 package software.amazon.kinesis.connectors.flink.serialization;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema.InitializationContext;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
@@ -31,6 +32,18 @@ import java.nio.ByteBuffer;
  */
 @PublicEvolving
 public interface KinesisSerializationSchema<T> extends Serializable {
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #serialize(Object)} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link InitializationContext} can be used to access additional features such
+	 * as e.g. registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(InitializationContext context) throws Exception {
+	}
+
 	/**
 	 * Serialize the given element into a ByteBuffer.
 	 *

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicSink.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicSink.java
@@ -1,0 +1,166 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import software.amazon.kinesis.connectors.flink.FlinkKinesisProducer;
+import software.amazon.kinesis.connectors.flink.KinesisPartitioner;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Kinesis-backed {@link DynamicTableSink}.
+ */
+@Internal
+public class KinesisDynamicSink implements DynamicTableSink, SupportsPartitioning {
+
+	/** Consumed data type of the table. */
+	private final DataType consumedDataType;
+
+	/** The Kinesis stream to write to. */
+	private final String stream;
+
+	/** Properties for the Kinesis producer. */
+	private final Properties producerProperties;
+
+	/** Sink format for encoding records to Kinesis. */
+	private final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
+
+	/** Partitioner to select Kinesis partition for each item. */
+	private final KinesisPartitioner<RowData> partitioner;
+
+	public KinesisDynamicSink(
+		DataType consumedDataType,
+		String stream,
+		Properties producerProperties,
+		EncodingFormat<SerializationSchema<RowData>> encodingFormat,
+		KinesisPartitioner<RowData> partitioner) {
+
+		this.consumedDataType = Preconditions.checkNotNull(
+			consumedDataType,
+			"Consumed data type must not be null");
+		this.stream = Preconditions.checkNotNull(
+			stream,
+			"Kinesis stream name must not be null");
+		this.producerProperties = Preconditions.checkNotNull(
+			producerProperties,
+			"Properties for the Flink Kinesis producer must not be null");
+		this.encodingFormat = Preconditions.checkNotNull(
+			encodingFormat,
+			"Encoding format must not be null");
+		this.partitioner = Preconditions.checkNotNull(
+			partitioner,
+			"Kinesis partitioner must not be null");
+	}
+
+	@Override
+	public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+		return encodingFormat.getChangelogMode();
+	}
+
+	@Override
+	public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+		SerializationSchema<RowData> serializationSchema =
+			encodingFormat.createRuntimeEncoder(context, consumedDataType);
+
+		FlinkKinesisProducer<RowData> kinesisProducer = new FlinkKinesisProducer<>(
+			serializationSchema,
+			producerProperties);
+		kinesisProducer.setDefaultStream(stream);
+		kinesisProducer.setCustomPartitioner(partitioner);
+
+		return SinkFunctionProvider.of(kinesisProducer);
+	}
+
+	@Override
+	public DynamicTableSink copy() {
+		return new KinesisDynamicSink(
+			consumedDataType,
+			stream,
+			producerProperties,
+			encodingFormat,
+			partitioner);
+	}
+
+	@Override
+	public String asSummaryString() {
+		return "Kinesis";
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// SupportsPartitioning
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public void applyStaticPartition(Map<String, String> partition) {
+		if (partitioner instanceof RowDataFieldsKinesisPartitioner) {
+			((RowDataFieldsKinesisPartitioner) partitioner).setStaticFields(partition);
+		} else {
+			String msg = "" +
+				"Cannot apply static partition optimization to a partition class " +
+				"that does not inherit from " +
+				"software.amazon.kinesis.connectors.flink.table.RowDataKinesisPartitioner.";
+			throw new RuntimeException(msg);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Value semantics for equals and hashCode
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		KinesisDynamicSink that = (KinesisDynamicSink) o;
+		return Objects.equals(consumedDataType, that.consumedDataType) &&
+			Objects.equals(stream, that.stream) &&
+			Objects.equals(producerProperties, that.producerProperties) &&
+			Objects.equals(encodingFormat, that.encodingFormat) &&
+			Objects.equals(partitioner, that.partitioner);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			consumedDataType,
+			stream,
+			producerProperties,
+			encodingFormat,
+			partitioner);
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicSource.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicSource.java
@@ -1,0 +1,156 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
+import software.amazon.kinesis.connectors.flink.serialization.KinesisDeserializationSchema;
+import software.amazon.kinesis.connectors.flink.serialization.KinesisDeserializationSchemaWrapper;
+
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Kinesis-backed {@link ScanTableSource}.
+ */
+@Internal
+public class KinesisDynamicSource implements ScanTableSource {
+
+	// --------------------------------------------------------------------------------------------
+	// Scan format attributes
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Data type to configure the format.
+	 */
+	private final DataType physicalDataType;
+
+	/**
+	 * Scan format for decoding records from Kinesis.
+	 */
+	private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
+
+	// --------------------------------------------------------------------------------------------
+	// Kinesis-specific attributes
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * The Kinesis stream to consume.
+	 */
+	private final String stream;
+
+	/**
+	 * Properties for the Kinesis consumer.
+	 */
+	private final Properties consumerProperties;
+
+	public KinesisDynamicSource(
+			DataType physicalDataType,
+			String stream,
+			Properties consumerProperties,
+			DecodingFormat<DeserializationSchema<RowData>> decodingFormat) {
+
+		this.physicalDataType = Preconditions.checkNotNull(
+				physicalDataType,
+				"Physical data type must not be null.");
+		this.stream = Preconditions.checkNotNull(
+				stream,
+				"Stream must not be null.");
+		this.consumerProperties = Preconditions.checkNotNull(
+				consumerProperties,
+				"Properties for the Flink Kinesis consumer must not be null.");
+		this.decodingFormat = Preconditions.checkNotNull(
+				decodingFormat,
+				"Decoding format must not be null.");
+	}
+
+	@Override
+	public ChangelogMode getChangelogMode() {
+		return decodingFormat.getChangelogMode();
+	}
+
+	@Override
+	public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+		KinesisDeserializationSchema<RowData> deserializationSchema;
+		DeserializationSchema<RowData> x = decodingFormat.createRuntimeDecoder(runtimeProviderContext, physicalDataType);
+
+		deserializationSchema = new KinesisDeserializationSchemaWrapper<>(x);
+
+		FlinkKinesisConsumer<RowData> kinesisConsumer = new FlinkKinesisConsumer<>(
+				stream,
+				deserializationSchema,
+				consumerProperties);
+
+		return SourceFunctionProvider.of(kinesisConsumer, false);
+	}
+
+	@Override
+	public DynamicTableSource copy() {
+		return new KinesisDynamicSource(
+				physicalDataType,
+				stream,
+				consumerProperties,
+				decodingFormat);
+	}
+
+	@Override
+	public String asSummaryString() {
+		return "Kinesis";
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Value semantics for equals and hashCode
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		KinesisDynamicSource that = (KinesisDynamicSource) o;
+		return Objects.equals(physicalDataType, that.physicalDataType) &&
+				Objects.equals(stream, that.stream) &&
+				Objects.equals(consumerProperties, that.consumerProperties) &&
+				Objects.equals(decodingFormat, that.decodingFormat);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+				physicalDataType,
+				stream,
+				consumerProperties,
+				decodingFormat);
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactory.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactory.java
@@ -1,0 +1,170 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+
+import software.amazon.kinesis.connectors.flink.util.KinesisConfigUtil;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Factory for creating {@link KinesisDynamicSource} and {@link KinesisDynamicSink} instances.
+ */
+@Internal
+public class KinesisDynamicTableFactory implements
+	DynamicTableSourceFactory,
+	DynamicTableSinkFactory {
+	public static final String IDENTIFIER = "kinesis";
+
+	// --------------------------------------------------------------------------------------------
+	// DynamicTableSourceFactory
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+		ReadableConfig tableOptions = helper.getOptions();
+		CatalogTable catalogTable = context.getCatalogTable();
+		Properties properties = KinesisOptions.getConsumerProperties(catalogTable.getOptions());
+
+		// initialize the table format early in order to register its consumedOptionKeys
+		// in the TableFactoryHelper, as those are needed for correct option validation
+		DecodingFormat<DeserializationSchema<RowData>> decodingFormat = helper
+			.discoverDecodingFormat(DeserializationFormatFactory.class, FactoryUtil.FORMAT);
+
+		// Validate option data types
+		helper.validateExcept(KinesisOptions.NON_VALIDATED_PREFIXES);
+		// Validate option values
+		validateConsumerProperties(tableOptions.get(KinesisOptions.STREAM), properties);
+
+		return new KinesisDynamicSource(
+			catalogTable.getSchema().toPhysicalRowDataType(),
+			tableOptions.get(KinesisOptions.STREAM),
+			properties,
+			decodingFormat
+		);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// DynamicTableSinkFactory
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+		ReadableConfig tableOptions = helper.getOptions();
+		CatalogTable catalogTable = context.getCatalogTable();
+		Properties properties = KinesisOptions.getProducerProperties(catalogTable.getOptions());
+
+		// initialize the table format early in order to register its consumedOptionKeys
+		// in the TableFactoryHelper, as those are needed for correct option validation
+		EncodingFormat<SerializationSchema<RowData>> encodingFormat = helper
+			.discoverEncodingFormat(SerializationFormatFactory.class, FactoryUtil.FORMAT);
+
+		// validate the data types of the table options
+		helper.validateExcept(KinesisOptions.NON_VALIDATED_PREFIXES);
+		// Validate option values
+		validateKinesisPartitioner(tableOptions, catalogTable);
+		validateProducerProperties(properties);
+
+		return new KinesisDynamicSink(
+			catalogTable.getSchema().toPhysicalRowDataType(),
+			tableOptions.get(KinesisOptions.STREAM),
+			properties,
+			encodingFormat,
+			KinesisOptions.getKinesisPartitioner(
+				tableOptions,
+				catalogTable,
+				context.getClassLoader()));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Factory
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		final Set<ConfigOption<?>> options = new HashSet<>();
+		options.add(KinesisOptions.STREAM);
+		options.add(FactoryUtil.FORMAT);
+		return options;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		final Set<ConfigOption<?>> options = new HashSet<>();
+		options.add(KinesisOptions.SINK_PARTITIONER);
+		options.add(KinesisOptions.SINK_PARTITIONER_FIELD_DELIMITER);
+		return options;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Validation helpers
+	// --------------------------------------------------------------------------------------------
+
+	private static void validateConsumerProperties(String stream, Properties properties) {
+		List<String> streams = Collections.singletonList(stream);
+		KinesisConfigUtil.validateConsumerConfiguration(properties, streams);
+	}
+
+	private static void validateProducerProperties(Properties properties) {
+		// this assumes no side-effects as it is also called later from FlinkKinesisProducer#open()
+		KinesisConfigUtil.getValidatedProducerConfiguration(properties);
+	}
+
+	public static void validateKinesisPartitioner(
+		ReadableConfig tableOptions,
+		CatalogTable targetTable) {
+		tableOptions.getOptional(KinesisOptions.SINK_PARTITIONER).ifPresent(partitioner -> {
+			if (targetTable.isPartitioned()) {
+				throw new ValidationException(String.format(
+					"Cannot set %s option for a table defined with a PARTITIONED BY clause",
+					KinesisOptions.SINK_PARTITIONER.key()));
+			}
+		});
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisOptions.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/KinesisOptions.java
@@ -1,0 +1,286 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import software.amazon.kinesis.connectors.flink.FixedKinesisPartitioner;
+import software.amazon.kinesis.connectors.flink.KinesisPartitioner;
+import software.amazon.kinesis.connectors.flink.RandomKinesisPartitioner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Options for Kinesis tables supported by the {@code CREATE TABLE ... WITH ...} clause of the
+ * Flink SQL dialect and the Flink Table API.
+ */
+@Internal
+public class KinesisOptions {
+
+	private KinesisOptions() {
+	}
+
+	// -----------------------------------------------------------------------------------------
+	// Kinesis specific options
+	// -----------------------------------------------------------------------------------------
+
+	/**
+	 * Prefix for properties defined in
+	 * {@link software.amazon.kinesis.connectors.flink.config.AWSConfigConstants}
+	 * that are delegated to
+	 * {@link software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer} and
+	 * {@link software.amazon.kinesis.connectors.flink.FlinkKinesisProducer}.
+	 */
+	public static final String AWS_PROPERTIES_PREFIX = "aws.";
+
+	/**
+	 * Prefix for properties defined in
+	 * {@link software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants}
+	 * that are delegated to
+	 * {@link software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer}.
+	 */
+	public static final String CONSUMER_PREFIX = "scan.";
+
+	/**
+	 * Prefix for properties defined in
+	 * {@link com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration}
+	 * that are delegated to
+	 * {@link software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer}.
+	 */
+	public static final String PRODUCER_PREFIX = "sink.producer.";
+
+	/**
+	 * Prefixes of properties that are validated by downstream components and should not be
+	 * validated by the Table API infrastructure.
+	 */
+	public static final String[] NON_VALIDATED_PREFIXES = new String[]{
+		AWS_PROPERTIES_PREFIX,
+		CONSUMER_PREFIX,
+		PRODUCER_PREFIX
+	};
+
+	public static final ConfigOption<String> STREAM = ConfigOptions
+		.key("stream")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Name of the Kinesis stream backing this table (required)");
+
+	// -----------------------------------------------------------------------------------------
+	// Sink specific options
+	// -----------------------------------------------------------------------------------------
+
+	public static final ConfigOption<String> SINK_PARTITIONER = ConfigOptions
+		.key("sink.partitioner")
+		.stringType()
+		.noDefaultValue()
+		.withDescription(
+			"Optional output partitioning from Flink's partitions into Kinesis shards. "
+				+ "Sinks that write to tables defined with the PARTITION BY clause "
+				+ "always use a field-based partitioner and cannot define this option. "
+				+ "Valid enumerations are: \n"
+				+ "\"random\":"
+				+ " (use a random partition key),\n"
+				+ "\"fixed\":"
+				+ " (each Flink partition ends up in at most one Kinesis shard),\n"
+				+ "\"custom class name\":"
+				+ " (use a custom " + KinesisPartitioner.class.getName() + " subclass)");
+
+	public static final ConfigOption<String> SINK_PARTITIONER_FIELD_DELIMITER = ConfigOptions
+		.key("sink.partitioner-field-delimiter")
+		.stringType()
+		.defaultValue("|")
+		.withDescription(
+			"Optional field delimiter for fields-based partitioner "
+				+ "derived from a PARTITION BY clause (\"|\" by default)");
+
+	// -----------------------------------------------------------------------------------------
+	// Option enumerations
+	// -----------------------------------------------------------------------------------------
+
+	public static final String SINK_PARTITIONER_VALUE_FIXED = "fixed";
+
+	public static final String SINK_PARTITIONER_VALUE_RANDOM = "random";
+
+	// -----------------------------------------------------------------------------------------
+	// Utilities
+	// -----------------------------------------------------------------------------------------
+
+	/** Options handled and validated by the table-level layer. */
+	public static final Set<String> TABLE_LEVEL_OPTIONS = new HashSet<>(Arrays.asList(
+		STREAM.key(),
+		FactoryUtil.FORMAT.key(),
+		SINK_PARTITIONER.key(),
+		SINK_PARTITIONER_FIELD_DELIMITER.key()
+	));
+
+	/** Derive properties to be passed to the {@code FlinkKinesisConsumer}. */
+	public static Properties getConsumerProperties(Map<String, String> tableOptions) {
+		Properties properties = new Properties();
+
+		for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+			String sourceKey = entry.getKey();
+			String sourceVal = entry.getValue();
+
+			if (!TABLE_LEVEL_OPTIONS.contains(sourceKey)) {
+				if (sourceKey.startsWith(AWS_PROPERTIES_PREFIX)) {
+					properties.put(translateAwsKey(sourceKey), sourceVal);
+				} else if (sourceKey.startsWith(CONSUMER_PREFIX)) {
+					properties.put(translateConsumerKey(sourceKey), sourceVal);
+				}
+			}
+		}
+
+		return properties;
+	}
+
+	/** Derive properties to be passed to the {@code FlinkKinesisProducer}. */
+	public static Properties getProducerProperties(Map<String, String> tableOptions) {
+		Properties properties = new Properties();
+
+		for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+			String sourceKey = entry.getKey();
+			String sourceVal = entry.getValue();
+
+			if (!TABLE_LEVEL_OPTIONS.contains(sourceKey)) {
+				if (sourceKey.startsWith(AWS_PROPERTIES_PREFIX)) {
+					properties.put(translateAwsKey(sourceKey), sourceVal);
+				} else if (sourceKey.startsWith(PRODUCER_PREFIX)) {
+					properties.put(translateProducerKey(sourceKey), sourceVal);
+				}
+			}
+		}
+
+		return properties;
+	}
+
+	/** Map {@code scan.foo.bar} to {@code flink.foo.bar}. */
+	private static String translateAwsKey(String key) {
+		if (!key.endsWith("credentials.provider")) {
+			return key.replace("credentials.", "credentials.provider.");
+		} else {
+			return key;
+		}
+	}
+
+	/** Map {@code scan.foo.bar} to {@code flink.foo.bar}. */
+	private static String translateConsumerKey(String key) {
+		String result = "flink." + key.substring(CONSUMER_PREFIX.length());
+
+		if (result.endsWith("initpos-timestamp-format")) {
+			return result.replace("initpos-timestamp-format", "initpos.timestamp.format");
+		} else if (result.endsWith("initpos-timestamp")) {
+			return result.replace("initpos-timestamp", "initpos.timestamp");
+		} else {
+			return result;
+		}
+	}
+
+	/** Map {@code sink.foo-bar} to {@code FooBar}. */
+	private static String translateProducerKey(String key) {
+		String suffix = key.substring(PRODUCER_PREFIX.length());
+		return Arrays.stream(suffix.split("-"))
+			.map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
+			.collect(Collectors.joining(""));
+	}
+
+	/**
+	 * Constructs the kinesis partitioner for a {@code targetTable} based on the currently set
+	 * {@code tableOptions}.
+	 *
+	 * <p>The following rules are applied with decreasing precedence order.</p>
+	 *
+	 * <ul>
+	 *   <li>If {@code targetTable} is partitioned, return a {@code RowDataKinesisPartitioner}.</li>
+	 *   <li>If the partitioner type is not set, return a {@link RandomKinesisPartitioner}.</li>
+	 *   <li>If a specific partitioner type alias is used, instantiate the corresponding type</li>
+	 *   <li>Interpret the partitioner type as a classname of a user-defined partitioner.</li>
+	 * </ul>
+	 *
+	 * @param tableOptions A read-only set of config options that determines the partitioner type.
+	 * @param targetTable A catalog version of the table backing the partitioner.
+	 * @param classLoader A {@link ClassLoader} to use for loading user-defined partitioner classes.
+	 */
+	public static KinesisPartitioner<RowData> getKinesisPartitioner(
+		ReadableConfig tableOptions,
+		CatalogTable targetTable,
+		ClassLoader classLoader) {
+
+		if (targetTable.isPartitioned()) {
+			String delimiter = tableOptions.get(SINK_PARTITIONER_FIELD_DELIMITER);
+			return new RowDataFieldsKinesisPartitioner(targetTable, delimiter);
+		} else if (!tableOptions.getOptional(SINK_PARTITIONER).isPresent()) {
+			return new RandomKinesisPartitioner<>();
+		} else {
+			String partitioner = tableOptions.getOptional(SINK_PARTITIONER).get();
+			if (SINK_PARTITIONER_VALUE_FIXED.equals(partitioner)) {
+				return new FixedKinesisPartitioner<>();
+			} else if (SINK_PARTITIONER_VALUE_RANDOM.equals(partitioner)) {
+				return new RandomKinesisPartitioner<>();
+			} else { // interpret the option value as a fully-qualified class name
+				return initializePartitioner(partitioner, classLoader);
+			}
+		}
+
+	}
+
+	/**
+	 * Returns a class value with the given class name.
+	 */
+	private static <T> KinesisPartitioner<T> initializePartitioner(
+		String name,
+		ClassLoader classLoader) {
+		try {
+			Class<?> clazz = Class.forName(name, true, classLoader);
+			if (!KinesisPartitioner.class.isAssignableFrom(clazz)) {
+				throw new ValidationException(
+					String.format(
+						"Partitioner class '%s' should have %s in its parents chain",
+						name,
+						KinesisPartitioner.class.getName()));
+			}
+			@SuppressWarnings("unchecked")
+			final KinesisPartitioner<T> partitioner = InstantiationUtil.instantiate(
+				name,
+				KinesisPartitioner.class,
+				classLoader);
+
+			return partitioner;
+		} catch (ClassNotFoundException | FlinkException e) {
+			throw new ValidationException(
+				String.format("Could not find and instantiate partitioner class '%s'", name),
+				e);
+		}
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitioner.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitioner.java
@@ -1,0 +1,307 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.Preconditions;
+
+import software.amazon.kinesis.connectors.flink.KinesisPartitioner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * <p>A {@link KinesisPartitioner} of {@link RowData} elements that constructs the partition key
+ * from a list of field names.</p>
+ *
+ * <p>The key is constructed by concatenating the string representations of a list of fields
+ * projected from an input element. A fixed prefix can be optionally configured in order to speed
+ * up the key construction process.</p>
+ *
+ * <p>Resulting partition key values are trimmed to the maximum length allowed by Kinesis.</p>
+ */
+@Internal
+public final class RowDataFieldsKinesisPartitioner extends KinesisPartitioner<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Allowed maximum length limit of a partition key.
+	 *
+	 * @link https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax
+	 */
+	public static final int MAX_PARTITION_KEY_LENGTH = 256;
+
+	/**
+	 * Default delimiter for {@link RowDataFieldsKinesisPartitioner#delimiter}.
+	 */
+	public static final String DEFAULT_DELIMITER = String.valueOf('|');
+
+	/**
+	 * The character used to delimit field values in the concatenated partition key string.
+	 */
+	private final String delimiter;
+
+	/**
+	 * A list of field names used to extract the partition key for a record that will be written to
+	 * a Kinesis stream.
+	 */
+	private final List<String> fieldNames;
+
+	/**
+	 * A map of getter functions to dynamically extract the field values for all
+	 * {@link RowDataFieldsKinesisPartitioner#fieldNames} from an input record.
+	 */
+	private final Map<String, RowData.FieldGetter> dynamicFieldGetters;
+
+	/**
+	 * A buffer used to accumulate the concatenation of all field values that form the partition
+	 * key.
+	 */
+	private final StringBuilder keyBuffer = new StringBuilder();
+
+	/**
+	 * A prefix of static field values to be used instead of the corresponding
+	 * {@link RowDataFieldsKinesisPartitioner#dynamicFieldGetters} entries.
+	 */
+	private Map<String, String> staticFields = Collections.emptyMap();
+
+	/**
+	 * The length of the static prefix of the {@link RowDataFieldsKinesisPartitioner#keyBuffer}
+	 * (derived from the values in {@link RowDataFieldsKinesisPartitioner#staticFields}).
+	 */
+	private int keyBufferStaticPrefixLength = 0;
+
+	/**
+	 * The length of the prefix in {@link RowDataFieldsKinesisPartitioner#fieldNames} for which
+	 * static field values are present in {@link RowDataFieldsKinesisPartitioner#staticFields}.
+	 */
+	private int fieldNamesStaticPrefixLength = 0;
+
+	public RowDataFieldsKinesisPartitioner(CatalogTable table) {
+		this(table, DEFAULT_DELIMITER);
+	}
+
+	public RowDataFieldsKinesisPartitioner(CatalogTable table, String delimiter) {
+		Preconditions.checkNotNull(table, "table");
+		Preconditions.checkNotNull(delimiter, "delimiter");
+		Preconditions.checkArgument(
+			table.isPartitioned(),
+			"Cannot create a RowDataFieldsKinesisPartitioner for a non-partitioned table");
+		Preconditions.checkArgument(
+			table.getPartitionKeys().size() == new HashSet<>(table.getPartitionKeys()).size(),
+			"The sequence of partition keys cannot contain duplicates");
+
+		TableSchema schema = table.getSchema();
+		List<String> schemaFieldsList = Arrays.asList(schema.getFieldNames());
+
+		List<String> badKeyNames = new ArrayList<>();
+		List<String> badKeyTypes = new ArrayList<>();
+
+		for (String fieldName : table.getPartitionKeys()) {
+			Optional<DataType> dataType = schema.getFieldDataType(fieldName);
+			if (!dataType.isPresent()) {
+				badKeyNames.add(fieldName);
+			} else if (!hasWellDefinedString(dataType.get().getLogicalType())) {
+				badKeyTypes.add(fieldName);
+			}
+		}
+
+		Preconditions.checkArgument(
+			badKeyNames.size() == 0,
+			"The following partition keys are not present in the table: %s",
+			String.join(", ", badKeyNames));
+		Preconditions.checkArgument(
+			badKeyTypes.size() == 0,
+			"The following partition keys have types that are not supported by Kinesis: %s",
+			String.join(", ", badKeyTypes));
+
+		this.delimiter = delimiter;
+		this.fieldNames = table.getPartitionKeys();
+		this.dynamicFieldGetters = new HashMap<>();
+		for (String fieldName : table.getPartitionKeys()) {
+			TableColumn column = schema
+				.getTableColumn(fieldName)
+				.orElseThrow(() -> new RuntimeException("Unexpected field column " + fieldName));
+
+			RowData.FieldGetter fieldGetter = RowData.createFieldGetter(
+				column.getType().getLogicalType(),
+				schemaFieldsList.indexOf(column.getName()));
+
+			this.dynamicFieldGetters.put(fieldName, fieldGetter);
+		}
+	}
+
+	@Override
+	public String getPartitionId(RowData element) {
+		// reset the buffer to the end of the static prefix size
+		keyBuffer.setLength(keyBufferStaticPrefixLength);
+
+		// fill in the dynamic part of the buffer
+		for (int i = fieldNamesStaticPrefixLength; i < fieldNames.size(); i++) {
+			String fieldName = fieldNames.get(i);
+			if (!staticFields.containsKey(fieldName)) {
+				keyBuffer.append(dynamicFieldGetters.get(fieldName).getFieldOrNull(element));
+			} else {
+				keyBuffer.append(staticFields.get(fieldName));
+			}
+			keyBuffer.append(delimiter);
+
+			if (keyBuffer.length() >= MAX_PARTITION_KEY_LENGTH) {
+				break; // stop when the buffer length exceeds the allowed partition key size
+			}
+		}
+
+		// return the accumulated concatenated string trimmed to the max allowed partition key size
+		int length = Math.min(keyBuffer.length() - delimiter.length(), MAX_PARTITION_KEY_LENGTH);
+		return keyBuffer.substring(0, length);
+	}
+
+	/**
+	 * Update the fixed partition key prefix.
+	 *
+	 * @param staticFields An association of (field name, field value) pairs to be used as static
+	 * 	partition key prefix.
+	 */
+	public void setStaticFields(Map<String, String> staticFields) {
+		Preconditions.checkArgument(
+			isPartitionKeySubset(staticFields.keySet()),
+			String.format(
+				"Not all static field names (%s) are part of the partition key (%s).",
+				String.join(", ", staticFields.keySet()),
+				String.join(", ", fieldNames)
+			));
+		this.staticFields = new HashMap<>(staticFields);
+		updateKeyBufferStaticPrefix();
+	}
+
+	/**
+	 * Check whether the set of field names in {@code candidatePrefix} forms a valid subset of the
+	 * set of field names defined in {@link RowDataFieldsKinesisPartitioner#fieldNames}.
+	 *
+	 * @param candidateSubset A set of field names forming a candidate subset of
+	 *    {@link RowDataFieldsKinesisPartitioner#fieldNames}.
+	 *
+	 * @return true if and only if the {@code candidatePrefix} is a proper subset of
+	 *    {@link RowDataFieldsKinesisPartitioner#fieldNames}.
+	 */
+	private boolean isPartitionKeySubset(Set<String> candidateSubset) {
+		return new HashSet<>(fieldNames).containsAll(candidateSubset);
+	}
+
+	/**
+	 * Pre-fills a prefix with static partition key values in the
+	 * {@link RowDataFieldsKinesisPartitioner#keyBufferStaticPrefixLength} buffer based on the
+	 * currently set {@link RowDataFieldsKinesisPartitioner#staticFields}.
+	 */
+	private void updateKeyBufferStaticPrefix() {
+		// update the fixed prefix and its cumulative length
+		keyBuffer.setLength(0);
+		fieldNamesStaticPrefixLength = 0;
+		for (String fieldName : fieldNames) {
+			if (staticFields.containsKey(fieldName)) {
+				keyBuffer.append(staticFields.get(fieldName));
+				keyBuffer.append(delimiter);
+				fieldNamesStaticPrefixLength++;
+			} else {
+				break; // stop on first static field
+			}
+		}
+		keyBufferStaticPrefixLength = keyBuffer.length();
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Value semantics for equals and hashCode
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final RowDataFieldsKinesisPartitioner that = (RowDataFieldsKinesisPartitioner) o;
+		return Objects.equals(this.delimiter, that.delimiter) &&
+			Objects.equals(this.fieldNames, that.fieldNames) &&
+			Objects.equals(this.staticFields, that.staticFields) &&
+			Objects.equals(this.keyBufferStaticPrefixLength, that.keyBufferStaticPrefixLength) &&
+			Objects.equals(this.fieldNamesStaticPrefixLength, that.fieldNamesStaticPrefixLength);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			delimiter,
+			fieldNames,
+			staticFields,
+			keyBufferStaticPrefixLength,
+			fieldNamesStaticPrefixLength);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Utilities
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Checks whether the given {@link LogicalType} has a well-defined string representation when
+	 * calling {@link Object#toString()} on the internal data structure. The string representation
+	 * would be similar in SQL or in a programming language.
+	 *
+	 * <p>Note: This method might not be necessary anymore, once we have implemented a utility that
+	 * can convert any internal data structure to a well-defined string representation.
+	 */
+	public static boolean hasWellDefinedString(LogicalType logicalType) {
+		if (logicalType instanceof DistinctType) {
+			return hasWellDefinedString(((DistinctType) logicalType).getSourceType());
+		}
+		switch (logicalType.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+			case BOOLEAN:
+			case TINYINT:
+			case SMALLINT:
+			case INTEGER:
+			case BIGINT:
+			case FLOAT:
+			case DOUBLE:
+				return true;
+			default:
+				return false;
+		}
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataKinesisDeserializationSchema.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataKinesisDeserializationSchema.java
@@ -1,0 +1,78 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Preconditions;
+
+import software.amazon.kinesis.connectors.flink.serialization.KinesisDeserializationSchema;
+
+import java.io.IOException;
+
+/**
+ * A {@link KinesisDeserializationSchema} adaptor for {@link RowData} records that delegates
+ * physical data deserialization to an inner {@link DeserializationSchema} and appends requested
+ * metadata to the end of the deserialized {@link RowData} record.
+ */
+@Internal
+public final class RowDataKinesisDeserializationSchema
+	implements KinesisDeserializationSchema<RowData> {
+
+	private static final long serialVersionUID = 5551095193778230749L;
+
+	/** A {@link DeserializationSchema} to deserialize the physical part of the row. */
+	private final DeserializationSchema<RowData> physicalDeserializer;
+
+	/** The type of the produced {@link RowData} records (physical data with appended metadata]. */
+	private final TypeInformation<RowData> producedTypeInfo;
+
+	public RowDataKinesisDeserializationSchema(
+		DeserializationSchema<RowData> physicalDeserializer,
+		TypeInformation<RowData> producedTypeInfo) {
+		this.physicalDeserializer = Preconditions.checkNotNull(physicalDeserializer);
+		this.producedTypeInfo = Preconditions.checkNotNull(producedTypeInfo);
+	}
+
+	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		physicalDeserializer.open(context);
+	}
+
+	@Override
+	public RowData deserialize(
+		byte[] recordValue,
+		String partitionKey,
+		String seqNum,
+		long approxArrivalTimestamp,
+		String stream,
+		String shardId) throws IOException {
+
+		return physicalDeserializer.deserialize(recordValue);
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return producedTypeInfo;
+	}
+}

--- a/src/main/java/software/amazon/kinesis/connectors/flink/util/JobManagerWatermarkTracker.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/util/JobManagerWatermarkTracker.java
@@ -146,7 +146,9 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
 				WatermarkState ws = e.getValue();
 				if (ws.lastUpdated + updateTimeoutMillis < currentTime) {
 					// ignore outdated entry
-					updateTimeoutCount++;
+					if (ws.watermark < Long.MAX_VALUE) {
+						updateTimeoutCount++;
+					}
 					continue;
 				}
 				globalWatermark = Math.min(ws.watermark, globalWatermark);

--- a/src/main/java/software/amazon/kinesis/connectors/flink/util/RecordEmitter.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/util/RecordEmitter.java
@@ -81,8 +81,6 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 	public interface RecordQueue<T> {
 		void put(T record) throws InterruptedException;
 
-		int getQueueId();
-
 		int getSize();
 
 		T peek();
@@ -100,6 +98,7 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 			this.headTimestamp = Long.MAX_VALUE;
 		}
 
+		@Override
 		public void put(T record) throws InterruptedException {
 			queue.put(record);
 			synchronized (condition) {
@@ -107,14 +106,12 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 			}
 		}
 
-		public int getQueueId() {
-			return queueId;
-		}
-
+		@Override
 		public int getSize() {
 			return queue.size();
 		}
 
+		@Override
 		public T peek() {
 			return queue.peek();
 		}
@@ -175,7 +172,14 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 	@Override
 	public void run() {
 		LOG.info("Starting emitter with maxLookaheadMillis: {}", this.maxLookaheadMillis);
+		emitRecords();
+	}
 
+	public void stop() {
+		running = false;
+	}
+
+	protected void emitRecords() {
 		// emit available records, ordered by timestamp
 		AsyncRecordQueue<T> min = heads.poll();
 		runLoop:
@@ -203,6 +207,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						}
 					}
 				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
+				}
 			}
 
 			// wait until ready to emit min or another queue receives elements
@@ -220,6 +228,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						min = null;
 						continue runLoop;
 					}
+				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
 				}
 			}
 
@@ -241,6 +253,11 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 			}
 			if (record == null) {
 				this.emptyQueues.put(min, true);
+			} else if (nextQueue != null && nextQueue.headTimestamp > min.headTimestamp) {
+				// if we stopped emitting due to reaching max timestamp,
+				// the next queue may not be the new min
+				heads.offer(nextQueue);
+				nextQueue = min;
 			} else {
 				heads.offer(min);
 			}
@@ -248,12 +265,8 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 		}
 	}
 
-	public void stop() {
-		running = false;
-	}
-
 	/** Emit the record. This is specific to a connector, like the Kinesis data fetcher. */
-	public abstract void emit(T record, RecordQueue<T> source);
+	protected abstract void emit(T record, RecordQueue<T> source);
 
 	/** Summary of emit queues that can be used for logging. */
 	public String printInfo() {

--- a/src/main/resources/META-INF/NOTICE
+++ b/src/main/resources/META-INF/NOTICE
@@ -12,58 +12,58 @@ Copyright 2014-2020 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.amazonaws:amazon-kinesis-client:1.14.0
+- com.amazonaws:amazon-kinesis-client:1.11.2
 - com.amazonaws:amazon-kinesis-producer:0.14.0
-- com.amazonaws:aws-java-sdk-core:1.11.804
-- com.amazonaws:aws-java-sdk-dynamodb:1.11.844
-- com.amazonaws:aws-java-sdk-kinesis:1.11.804
-- com.amazonaws:aws-java-sdk-kms:1.11.844
-- com.amazonaws:aws-java-sdk-s3:1.11.844
-- com.amazonaws:aws-java-sdk-sts:1.11.844
+- com.amazonaws:aws-java-sdk-core:1.11.754
+- com.amazonaws:aws-java-sdk-dynamodb:1.11.603
+- com.amazonaws:aws-java-sdk-kinesis:1.11.754
+- com.amazonaws:aws-java-sdk-kms:1.11.603
+- com.amazonaws:aws-java-sdk-s3:1.11.603
+- com.amazonaws:aws-java-sdk-sts:1.11.754
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.0
-- com.amazonaws:jmespath-java:1.11.844
-- org.apache.httpcomponents:httpclient:4.5.3
-- org.apache.httpcomponents:httpcore:4.4.6
-- software.amazon.ion:ion-java:jar:1.0.2
-- software.amazon.awssdk:kinesis:jar:2.13.52
-- software.amazon.awssdk:aws-cbor-protocol:jar:2.13.52
-- software.amazon.awssdk:aws-json-protocol:jar:2.13.52
-- software.amazon.awssdk:protocol-core:jar:2.13.52
-- software.amazon.awssdk:profiles:jar:2.13.52
-- software.amazon.awssdk:sdk-core:jar:2.13.52
-- software.amazon.awssdk:auth:jar:2.13.52
-- software.amazon.eventstream:eventstream:jar:1.0.1
-- software.amazon.awssdk:http-client-spi:jar:2.13.52
-- software.amazon.awssdk:regions:jar:2.13.52
-- software.amazon.awssdk:annotations:jar:2.13.52
-- software.amazon.awssdk:utils:jar:2.13.52
-- software.amazon.awssdk:aws-core:jar:2.13.52
-- software.amazon.awssdk:metrics-spi:jar:2.13.52
-- software.amazon.awssdk:apache-client:jar:2.13.52
-- software.amazon.awssdk:netty-nio-client:jar:2.13.52
-- software.amazon.awssdk:sts:jar:2.13.52
-- software.amazon.awssdk:aws-query-protocol:jar:2.13.52
-- io.netty:netty-codec-http:jar:4.1.46.Final
-- io.netty:netty-codec-http2:jar:4.1.46.Final
-- io.netty:netty-codec:jar:4.1.46.Final
-- io.netty:netty-transport:jar:4.1.46.Final
-- io.netty:netty-resolver:jar:4.1.46.Final
-- io.netty:netty-common:jar:4.1.46.Final
-- io.netty:netty-buffer:jar:4.1.46.Final
-- io.netty:netty-handler:jar:4.1.46.Final
-- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.46.Final
-- io.netty:netty-transport-native-unix-common:jar:4.1.46.Final
-- com.typesafe.netty:netty-reactive-streams-http:jar:2.0.4
-- com.typesafe.netty:netty-reactive-streams:jar:2.0.4
+- com.amazonaws:jmespath-java:1.11.754
+- org.apache.httpcomponents:httpclient:4.5.9
+- org.apache.httpcomponents:httpcore:4.4.11
+- software.amazon.ion:ion-java:1.0.2
+- software.amazon.awssdk:kinesis:2.13.52
+- software.amazon.awssdk:aws-cbor-protocol:2.13.52
+- software.amazon.awssdk:aws-json-protocol:2.13.52
+- software.amazon.awssdk:protocol-core:2.13.52
+- software.amazon.awssdk:profiles:2.13.52
+- software.amazon.awssdk:sdk-core:2.13.52
+- software.amazon.awssdk:auth:2.13.52
+- software.amazon.eventstream:eventstream:1.0.1
+- software.amazon.awssdk:http-client-spi:2.13.52
+- software.amazon.awssdk:regions:2.13.52
+- software.amazon.awssdk:annotations:2.13.52
+- software.amazon.awssdk:utils:2.13.52
+- software.amazon.awssdk:aws-core:2.13.52
+- software.amazon.awssdk:metrics-spi:2.13.52
+- software.amazon.awssdk:apache-client:2.13.52
+- software.amazon.awssdk:netty-nio-client:2.13.52
+- software.amazon.awssdk:sts:2.13.52
+- software.amazon.awssdk:aws-query-protocol:2.13.52
+- io.netty:netty-codec-http:4.1.46.Final
+- io.netty:netty-codec-http2:4.1.46.Final
+- io.netty:netty-codec:4.1.46.Final
+- io.netty:netty-transport:4.1.46.Final
+- io.netty:netty-resolver:4.1.46.Final
+- io.netty:netty-common:4.1.46.Final
+- io.netty:netty-buffer:4.1.46.Final
+- io.netty:netty-handler:4.1.46.Final
+- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.46.Final
+- io.netty:netty-transport-native-unix-common:4.1.46.Final
+- com.typesafe.netty:netty-reactive-streams-http:2.0.4
+- com.typesafe.netty:netty-reactive-streams:2.0.4
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:3.11.4
+- com.google.protobuf:protobuf-java:2.6.1
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 
-- org.reactivestreams:reactive-streams:jar:1.0.2
+- org.reactivestreams:reactive-streams:1.0.2
 
 The Amazon Kinesis Producer Library includes http-parser, Copyright (c) Joyent, Inc. and other Node contributors, libc++, Copyright (c) 2003-2014, LLVM Project, and slf4j, Copyright (c) 2004-2013 QOS.ch, each of which is subject to the terms and conditions of the MIT license that states as follows:
 

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+software.amazon.kinesis.connectors.flink.table.KinesisDynamicTableFactory

--- a/src/test/java/software/amazon/kinesis/connectors/flink/KinesisConsumerTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/KinesisConsumerTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Tests for {@link FlinkKinesisConsumer}. In contrast to tests in {@link FlinkKinesisConsumerTest} it does not
+ * use power mock, which makes it possible to use e.g. the {@link ExpectedException}.
+ */
+public class KinesisConsumerTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testKinesisConsumerThrowsExceptionIfSchemaImplementsCollector() {
+		DeserializationSchema<Object> schemaWithCollector = new DeserializationSchema<Object>() {
+			@Override
+			public Object deserialize(byte[] message) throws IOException {
+				return null;
+			}
+
+			@Override
+			public void deserialize(byte[] message, Collector<Object> out) throws IOException {
+				// we do not care about the implementation. we should just check if this method is declared
+			}
+
+			@Override
+			public boolean isEndOfStream(Object nextElement) {
+				return false;
+			}
+
+			@Override
+			public TypeInformation<Object> getProducedType() {
+				return null;
+			}
+		};
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(
+			"Kinesis consumer does not support DeserializationSchema that implements deserialization with a" +
+				" Collector. Unsupported DeserializationSchema: " +
+				"software.amazon.kinesis.connectors.flink.KinesisConsumerTest");
+		new FlinkKinesisConsumer<>("fakeStream", schemaWithCollector, new Properties());
+	}
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTest.java
@@ -38,6 +38,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
 import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.fakeSequenceNumber;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
@@ -85,8 +88,8 @@ public class ShardConsumerTest {
 		Date expectedTimestamp = new SimpleDateFormat(format).parse(timestamp);
 
 		Properties consumerProperties = new Properties();
-		consumerProperties.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, timestamp);
-		consumerProperties.setProperty(ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT, format);
+		consumerProperties.setProperty(STREAM_INITIAL_TIMESTAMP, timestamp);
+		consumerProperties.setProperty(STREAM_TIMESTAMP_DATE_FORMAT, format);
 		SequenceNumber sequenceNumber = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
 
 		KinesisProxyInterface kinesis = spy(FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(10, 1, 0));
@@ -117,7 +120,7 @@ public class ShardConsumerTest {
 	@Test
 	public void testCorrectNumOfCollectedRecordsAndUpdatedStateWithAdaptiveReads() throws Exception {
 		Properties consumerProperties = new Properties();
-		consumerProperties.setProperty(ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS, "true");
+		consumerProperties.setProperty(SHARD_USE_ADAPTIVE_READS, "true");
 
 		KinesisProxyInterface kinesis = FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2, 500L);
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTestUtils.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTestUtils.java
@@ -25,13 +25,11 @@ import org.apache.flink.metrics.MetricGroup;
 import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisherFactory;
 import software.amazon.kinesis.connectors.flink.metrics.ShardConsumerMetricsReporter;
 import software.amazon.kinesis.connectors.flink.model.KinesisStreamShardState;
-import software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber;
 import software.amazon.kinesis.connectors.flink.model.SequenceNumber;
 import software.amazon.kinesis.connectors.flink.model.StartingPosition;
 import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
@@ -51,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM;
 
 /**
  * Tests for the {@link ShardConsumer}.
@@ -103,12 +102,13 @@ public class ShardConsumerTestUtils {
 			shardIndex,
 			shardHandle,
 			lastProcessedSequenceNum,
-			shardMetricsReporter)
+			shardMetricsReporter,
+			deserializationSchema)
 			.run();
 
 		assertEquals(expectedNumberOfMessages, sourceContext.getCollectedOutputs().size());
-		Assert.assertEquals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+		assertEquals(
+			SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 
 		return shardMetricsReporter;

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/RecordBatchTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/RecordBatchTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static software.amazon.kinesis.connectors.flink.testutils.TestUtils.createDummyStreamShardHandle;
 
 /**
  * Tests for {@link RecordBatch}.
@@ -47,7 +48,7 @@ public class RecordBatchTest {
 			record("2"),
 			record("3"),
 			record("4")
-		), TestUtils.createDummyStreamShardHandle(), 100L);
+		), createDummyStreamShardHandle(), 100L);
 
 		assertEquals(4, result.getAggregatedRecordSize());
 		assertEquals(4, result.getDeaggregatedRecordSize());
@@ -58,7 +59,7 @@ public class RecordBatchTest {
 	@Test
 	public void testDeaggregateRecordsWithAggregatedRecords() {
 		final List<Record> records = TestUtils.createAggregatedRecordBatch(5, 5, new AtomicInteger());
-		RecordBatch result = new RecordBatch(records, TestUtils.createDummyStreamShardHandle(), 100L);
+		RecordBatch result = new RecordBatch(records, createDummyStreamShardHandle(), 100L);
 
 		assertEquals(5, result.getAggregatedRecordSize());
 		assertEquals(25, result.getDeaggregatedRecordSize());
@@ -68,7 +69,7 @@ public class RecordBatchTest {
 
 	@Test
 	public void testGetAverageRecordSizeBytesEmptyList() {
-		RecordBatch result = new RecordBatch(emptyList(), TestUtils.createDummyStreamShardHandle(), 100L);
+		RecordBatch result = new RecordBatch(emptyList(), createDummyStreamShardHandle(), 100L);
 
 		assertEquals(0, result.getAggregatedRecordSize());
 		assertEquals(0, result.getDeaggregatedRecordSize());
@@ -77,7 +78,7 @@ public class RecordBatchTest {
 
 	@Test
 	public void testGetMillisBehindLatest() {
-		RecordBatch result = new RecordBatch(singletonList(record("1")), TestUtils.createDummyStreamShardHandle(), 100L);
+		RecordBatch result = new RecordBatch(singletonList(record("1")), createDummyStreamShardHandle(), 100L);
 
 		assertEquals(Long.valueOf(100), result.getMillisBehindLatest());
 	}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -1,17 +1,20 @@
 /*
- *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * This file has been modified from the original.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License").
- *  You may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package software.amazon.kinesis.connectors.flink.internals.publisher.fanout;
@@ -41,7 +44,8 @@ public class FanOutShardSubscriberTest {
 
 		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
 
-		StartingPosition startingPosition = StartingPosition.builder().build();
+		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
+			.builder().build();
 		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
 	}
 
@@ -55,7 +59,8 @@ public class FanOutShardSubscriberTest {
 
 		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
 
-		StartingPosition startingPosition = StartingPosition.builder().build();
+		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
+			.builder().build();
 		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
 	}
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherConfigurationTest.java
@@ -20,13 +20,15 @@
 package software.amazon.kinesis.connectors.flink.internals.publisher.polling;
 
 import org.junit.Test;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SHARD_GETRECORDS_MAX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
 
 /**
  * Tests for {@link PollingRecordPublisherConfiguration}.
@@ -43,7 +45,7 @@ public class PollingRecordPublisherConfigurationTest {
 
 	@Test
 	public void testGetFetchIntervalMillis() {
-		Properties properties = properties(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS, "1");
+		Properties properties = properties(SHARD_GETRECORDS_INTERVAL_MILLIS, "1");
 		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
 
 		assertEquals(configuration.getFetchIntervalMillis(), 1);
@@ -51,7 +53,7 @@ public class PollingRecordPublisherConfigurationTest {
 
 	@Test
 	public void testGetMaxNumberOfRecordsPerFetch() {
-		Properties properties = properties(ConsumerConfigConstants.SHARD_GETRECORDS_MAX, "2");
+		Properties properties = properties(SHARD_GETRECORDS_MAX, "2");
 		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
 
 		assertEquals(configuration.getMaxNumberOfRecordsPerFetch(), 2);
@@ -59,7 +61,7 @@ public class PollingRecordPublisherConfigurationTest {
 
 	@Test
 	public void testIsAdaptiveReads() {
-		Properties properties = properties(ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS, "true");
+		Properties properties = properties(SHARD_USE_ADAPTIVE_READS, "true");
 		PollingRecordPublisherConfiguration configuration = new PollingRecordPublisherConfiguration(properties);
 
 		assertTrue(configuration.isAdaptiveReads());

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
@@ -22,7 +22,6 @@ package software.amazon.kinesis.connectors.flink.internals.publisher.polling;
 import org.apache.flink.metrics.MetricGroup;
 
 import org.junit.Test;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.model.StartingPosition;
 import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
@@ -33,6 +32,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 
 /**
@@ -57,7 +57,7 @@ public class PollingRecordPublisherFactoryTest {
 	@Test
 	public void testBuildAdaptivePollingRecordPublisher() throws Exception {
 		Properties properties = new Properties();
-		properties.setProperty(ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS, "true");
+		properties.setProperty(SHARD_USE_ADAPTIVE_READS, "true");
 
 		RecordPublisher recordPublisher = factory.create(
 			StartingPosition.restartFromSequenceNumber(SENTINEL_LATEST_SEQUENCE_NUM.get()),

--- a/src/test/java/software/amazon/kinesis/connectors/flink/manualtests/ManualExactlyOnceTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/manualtests/ManualExactlyOnceTest.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.manualtests;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -80,7 +81,7 @@ public class ManualExactlyOnceTest {
 		}
 
 		final Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("16m"));
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		MiniClusterResource flink = new MiniClusterResource(new MiniClusterResourceConfiguration.Builder()

--- a/src/test/java/software/amazon/kinesis/connectors/flink/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.manualtests;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -92,7 +93,7 @@ public class ManualExactlyOnceWithStreamReshardingTest {
 		}
 
 		final Configuration flinkConfig = new Configuration();
-		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+		flinkConfig.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("16m"));
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		MiniClusterResource flink = new MiniClusterResource(new MiniClusterResourceConfiguration.Builder()

--- a/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
@@ -36,7 +36,6 @@ import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerReque
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutRecordPublisherConfiguration;
 
 import java.util.Properties;
@@ -50,6 +49,25 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_DESCRIBE_RETRIES;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX;
 
 /**
  * Test for methods in the {@link KinesisProxyV2} class.
@@ -311,24 +329,24 @@ public class KinesisProxyV2Test {
 
 	private Properties createEfoProperties() {
 		Properties config = new Properties();
-		config.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.name());
-		config.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "dummy-efo-consumer");
-		config.setProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_BASE));
-		config.setProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_MAX));
-		config.setProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_POW));
-		config.setProperty(ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_BASE, String.valueOf(EXPECTED_REGISTRATION_BASE));
-		config.setProperty(ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_MAX, String.valueOf(EXPECTED_REGISTRATION_MAX));
-		config.setProperty(ConsumerConfigConstants.REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_REGISTRATION_POW));
-		config.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_BASE, String.valueOf(EXPECTED_DEREGISTRATION_BASE));
-		config.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_MAX, String.valueOf(EXPECTED_DEREGISTRATION_MAX));
-		config.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DEREGISTRATION_POW));
-		config.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_BASE));
-		config.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_MAX));
-		config.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_POW));
-		config.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE, String.valueOf(EXPECTED_DESCRIBE_STREAM_BASE));
-		config.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX, String.valueOf(EXPECTED_DESCRIBE_STREAM_MAX));
-		config.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DESCRIBE_STREAM_POW));
-		config.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_RETRIES, String.valueOf(EXPECTED_DESCRIBE_STREAM_RETRIES));
+		config.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		config.setProperty(EFO_CONSUMER_NAME, "dummy-efo-consumer");
+		config.setProperty(SUBSCRIBE_TO_SHARD_BACKOFF_BASE, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_BASE));
+		config.setProperty(SUBSCRIBE_TO_SHARD_BACKOFF_MAX, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_MAX));
+		config.setProperty(SUBSCRIBE_TO_SHARD_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_POW));
+		config.setProperty(REGISTER_STREAM_BACKOFF_BASE, String.valueOf(EXPECTED_REGISTRATION_BASE));
+		config.setProperty(REGISTER_STREAM_BACKOFF_MAX, String.valueOf(EXPECTED_REGISTRATION_MAX));
+		config.setProperty(REGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_REGISTRATION_POW));
+		config.setProperty(DEREGISTER_STREAM_BACKOFF_BASE, String.valueOf(EXPECTED_DEREGISTRATION_BASE));
+		config.setProperty(DEREGISTER_STREAM_BACKOFF_MAX, String.valueOf(EXPECTED_DEREGISTRATION_MAX));
+		config.setProperty(DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DEREGISTRATION_POW));
+		config.setProperty(DESCRIBE_STREAM_CONSUMER_BACKOFF_BASE, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_BASE));
+		config.setProperty(DESCRIBE_STREAM_CONSUMER_BACKOFF_MAX, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_MAX));
+		config.setProperty(DESCRIBE_STREAM_CONSUMER_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DESCRIBE_CONSUMER_POW));
+		config.setProperty(STREAM_DESCRIBE_BACKOFF_BASE, String.valueOf(EXPECTED_DESCRIBE_STREAM_BASE));
+		config.setProperty(STREAM_DESCRIBE_BACKOFF_MAX, String.valueOf(EXPECTED_DESCRIBE_STREAM_MAX));
+		config.setProperty(STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT, String.valueOf(EXPECTED_DESCRIBE_STREAM_POW));
+		config.setProperty(STREAM_DESCRIBE_RETRIES, String.valueOf(EXPECTED_DESCRIBE_STREAM_RETRIES));
 		return config;
 	}
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
@@ -1,0 +1,330 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
+import software.amazon.kinesis.connectors.flink.FlinkKinesisProducer;
+import software.amazon.kinesis.connectors.flink.RandomKinesisPartitioner;
+import software.amazon.kinesis.connectors.flink.testutils.TableOptionsBuilder;
+import software.amazon.kinesis.connectors.flink.testutils.TestFormatFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.flink.util.CoreMatchers.containsCause;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for {@link KinesisDynamicSource} and {@link KinesisDynamicSink} created
+ * by {@link KinesisDynamicTableFactory}.
+ */
+public class KinesisDynamicTableFactoryTest extends TestLogger {
+
+	private static final String STREAM_NAME = "myStream";
+
+	private static final String TABLE_NAME = "myTable";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	// --------------------------------------------------------------------------------------------
+	// Positive tests
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testGoodTableSource() {
+		TableSchema sourceSchema = defaultSourceSchema().build();
+		Map<String, String> sourceOptions = defaultTableOptions().build();
+		CatalogTable catalogTable = createSourceTable(sourceSchema, sourceOptions);
+
+		// Construct actual DynamicTableSource using FactoryUtil
+		KinesisDynamicSource actualSource = actualDynamicSource(catalogTable);
+
+		// Construct expected DynamicTableSink using factory under test
+		KinesisDynamicSource expectedSource = new KinesisDynamicSource(
+			sourceSchema.toPhysicalRowDataType(),
+			STREAM_NAME,
+			defaultConsumerProperties(),
+			new TestFormatFactory.DecodingFormatMock(",", true));
+
+		// verify that the constructed DynamicTableSink is as expected
+		assertEquals(expectedSource, actualSource);
+
+		// verify that the copy of the constructed DynamicTableSink is as expected
+		assertEquals(expectedSource, actualSource.copy());
+
+		// verify produced sink
+		ScanTableSource.ScanRuntimeProvider functionProvider =
+			actualSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+		SourceFunction<RowData> sourceFunction =
+			as(functionProvider, SourceFunctionProvider.class).createSourceFunction();
+		assertThat(sourceFunction, instanceOf(FlinkKinesisConsumer.class));
+	}
+
+	@Test
+	public void testGoodTableSinkForPartitionedTable() {
+		TableSchema sinkSchema = defaultSinkSchema().build();
+		Map<String, String> sinkOptions = defaultTableOptions().build();
+		List<String> sinkPartitionKeys = Arrays.asList("name", "curr_id");
+		CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions, sinkPartitionKeys);
+
+		// Construct actual DynamicTableSink using FactoryUtil
+		KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+
+		// Construct expected DynamicTableSink using factory under test
+		KinesisDynamicSink expectedSink = new KinesisDynamicSink(
+			sinkSchema.toPhysicalRowDataType(),
+			STREAM_NAME,
+			defaultProducerProperties(),
+			new TestFormatFactory.EncodingFormatMock(","),
+			new RowDataFieldsKinesisPartitioner(sinkTable));
+
+		// verify that the constructed DynamicTableSink is as expected
+		assertEquals(expectedSink, actualSink);
+
+		// verify that the copy of the constructed DynamicTableSink is as expected
+		assertEquals(expectedSink.copy(), actualSink);
+
+		// verify the produced sink
+		DynamicTableSink.SinkRuntimeProvider sinkFunctionProvider =
+			actualSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+		SinkFunction<RowData> sinkFunction =
+			as(sinkFunctionProvider, SinkFunctionProvider.class).createSinkFunction();
+		assertThat(sinkFunction, instanceOf(FlinkKinesisProducer.class));
+	}
+
+	@Test
+	public void testGoodTableSinkForNonPartitionedTable() {
+		TableSchema sinkSchema = defaultSinkSchema().build();
+		Map<String, String> sinkOptions = defaultTableOptions().build();
+		CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions);
+
+		// Construct actual DynamicTableSink using FactoryUtil
+		KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+
+		// Construct expected DynamicTableSink using factory under test
+		KinesisDynamicSink expectedSink = new KinesisDynamicSink(
+			sinkSchema.toPhysicalRowDataType(),
+			STREAM_NAME,
+			defaultProducerProperties(),
+			new TestFormatFactory.EncodingFormatMock(","),
+			new RandomKinesisPartitioner<>());
+
+		// verify that the constructed DynamicTableSink is as expected
+		assertEquals(expectedSink, actualSink);
+
+		// verify that the copy of the constructed DynamicTableSink is as expected
+		assertEquals(expectedSink.copy(), actualSink);
+
+		// verify the produced sink
+		DynamicTableSink.SinkRuntimeProvider sinkFunctionProvider =
+			actualSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+		SinkFunction<RowData> sinkFunction =
+			as(sinkFunctionProvider, SinkFunctionProvider.class).createSinkFunction();
+		assertThat(sinkFunction, instanceOf(FlinkKinesisProducer.class));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Negative tests
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testBadTableSinkForCustomPartitionerForPartitionedTable() {
+		TableSchema sinkSchema = defaultSinkSchema().build();
+		Map<String, String> sinkOptions = defaultTableOptions()
+			.withTableOption(KinesisOptions.SINK_PARTITIONER, "random")
+			.build();
+
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException(String.format(
+			"Cannot set %s option for a table defined with a PARTITIONED BY clause",
+			KinesisOptions.SINK_PARTITIONER.key()))));
+
+		try {
+			FactoryUtil.createTableSink(
+				null,
+				ObjectIdentifier.of("default", "default", TABLE_NAME),
+				createSinkTable(sinkSchema, sinkOptions, Arrays.asList("name", "curr_id")),
+				new Configuration(),
+				Thread.currentThread().getContextClassLoader());
+		} catch (ValidationException e) {
+			throw (ValidationException) e.getCause(); // unpack the causing exception
+		}
+	}
+
+	@Test
+	public void testBadTableSinkForNonExistingPartitionerClass() {
+		TableSchema sinkSchema = defaultSinkSchema().build();
+		Map<String, String> sinkOptions = defaultTableOptions()
+			.withTableOption(KinesisOptions.SINK_PARTITIONER, "abc")
+			.build();
+
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException(
+			"Could not find and instantiate partitioner class 'abc'")));
+
+		FactoryUtil.createTableSink(
+			null,
+			ObjectIdentifier.of("default", "default", TABLE_NAME),
+			createSinkTable(sinkSchema, sinkOptions, Collections.emptyList()),
+			new Configuration(),
+			Thread.currentThread().getContextClassLoader());
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Utilities
+	// --------------------------------------------------------------------------------------------
+
+	private CatalogTable createSourceTable(
+		TableSchema sourceSchema,
+		Map<String, String> sourceOptions) {
+		return createSourceTable(sourceSchema, sourceOptions, Collections.emptyList());
+	}
+
+	private CatalogTable createSourceTable(
+		TableSchema sourceSchema,
+		Map<String, String> sourceOptions,
+		List<String> partitionKeys) {
+		return new CatalogTableImpl(sourceSchema, partitionKeys, sourceOptions, TABLE_NAME);
+	}
+
+	private CatalogTable createSinkTable(
+		TableSchema sinkSchema,
+		Map<String, String> sinkOptions) {
+		return createSinkTable(sinkSchema, sinkOptions, Collections.emptyList());
+	}
+
+	private CatalogTable createSinkTable(
+		TableSchema sinkSchema,
+		Map<String, String> sinkOptions,
+		List<String> partitionKeys) {
+		return new CatalogTableImpl(sinkSchema, partitionKeys, sinkOptions, TABLE_NAME);
+	}
+
+	private TableSchema.Builder defaultSourceSchema() {
+		return TableSchema.builder()
+			.add(TableColumn.of("name", DataTypes.STRING()))
+			.add(TableColumn.of("curr_id", DataTypes.BIGINT()))
+			.add(TableColumn.of("time", DataTypes.TIMESTAMP(3)))
+			.add(TableColumn.of("next_id", DataTypes.BIGINT(), "curr_id + 1"))
+			.watermark("time", "time" + " - INTERVAL '5' SECOND", DataTypes.TIMESTAMP(3));
+	}
+
+	private TableSchema.Builder defaultSinkSchema() {
+		return TableSchema.builder()
+			.add(TableColumn.of("name", DataTypes.STRING()))
+			.add(TableColumn.of("curr_id", DataTypes.BIGINT()))
+			.add(TableColumn.of("time", DataTypes.TIMESTAMP(3)));
+	}
+
+	private TableOptionsBuilder defaultTableOptions() {
+		String connector = KinesisDynamicTableFactory.IDENTIFIER;
+		String format = TestFormatFactory.IDENTIFIER;
+		return new TableOptionsBuilder(connector, format)
+			// default table options
+			.withTableOption(KinesisOptions.STREAM, STREAM_NAME)
+			.withTableOption("aws.region", "us-west-2")
+			.withTableOption("aws.credentials.provider", "BASIC")
+			.withTableOption("aws.credentials.basic.accesskeyid", "ververicka")
+			.withTableOption("aws.credentials.basic.secretkey", "SuperSecretSecretSquirrel")
+			.withTableOption("scan.stream.initpos", "AT_TIMESTAMP")
+			.withTableOption("scan.stream.initpos-timestamp-format", "yyyy-MM-dd'T'HH:mm:ss")
+			.withTableOption("scan.stream.initpos-timestamp", "2014-10-22T12:00:00")
+			.withTableOption("sink.producer.collection-max-count", "100")
+			// default format options
+			.withFormatOption(TestFormatFactory.DELIMITER, ",")
+			.withFormatOption(TestFormatFactory.FAIL_ON_MISSING, "true");
+	}
+
+	private Properties defaultConsumerProperties() {
+		return new Properties() {{
+			setProperty("aws.region", "us-west-2");
+			setProperty("aws.credentials.provider", "BASIC");
+			setProperty("aws.credentials.provider.basic.accesskeyid", "ververicka");
+			setProperty("aws.credentials.provider.basic.secretkey", "SuperSecretSecretSquirrel");
+			setProperty("flink.stream.initpos", "AT_TIMESTAMP");
+			setProperty("flink.stream.initpos.timestamp.format", "yyyy-MM-dd'T'HH:mm:ss");
+			setProperty("flink.stream.initpos.timestamp", "2014-10-22T12:00:00");
+		}};
+	}
+
+	private Properties defaultProducerProperties() {
+		return new Properties() {{
+			setProperty("aws.region", "us-west-2");
+			setProperty("aws.credentials.provider", "BASIC");
+			setProperty("aws.credentials.provider.basic.accesskeyid", "ververicka");
+			setProperty("aws.credentials.provider.basic.secretkey", "SuperSecretSecretSquirrel");
+			setProperty("CollectionMaxCount", "100");
+		}};
+	}
+
+	private KinesisDynamicSource actualDynamicSource(CatalogTable catalogTable) {
+		return (KinesisDynamicSource)
+			FactoryUtil.createTableSource(
+				null,
+				ObjectIdentifier.of("default", "default", TABLE_NAME),
+				catalogTable,
+				new Configuration(),
+				Thread.currentThread().getContextClassLoader());
+	}
+
+	private KinesisDynamicSink actualDynamicSink(CatalogTable catalogTable) {
+		return (KinesisDynamicSink) FactoryUtil.createTableSink(
+			null,
+			ObjectIdentifier.of("default", "default", TABLE_NAME),
+			catalogTable,
+			new Configuration(),
+			Thread.currentThread().getContextClassLoader());
+	}
+
+	private <T> T as(Object object, Class<T> clazz) {
+		assertThat(object, instanceOf(clazz));
+		return clazz.cast(object);
+	}
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitionerTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitionerTest.java
@@ -1,0 +1,324 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.kinesis.connectors.flink.testutils.TableOptionsBuilder;
+import software.amazon.kinesis.connectors.flink.testutils.TestFormatFactory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.flink.table.utils.EncodingUtils.repeat;
+import static org.apache.flink.util.CoreMatchers.containsCause;
+import static org.junit.Assert.assertEquals;
+import static software.amazon.kinesis.connectors.flink.table.RowDataFieldsKinesisPartitioner.MAX_PARTITION_KEY_LENGTH;
+
+/**
+ * Test for {@link RowDataFieldsKinesisPartitioner}.
+ */
+public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
+
+	/**
+	 * Table name to use for the tests.
+	 */
+	private static final String TABLE_NAME = "click_stream";
+
+	/**
+	 * Table schema to use for the tests.
+	 */
+	private static final TableSchema TABLE_SCHEMA = TableSchema.builder()
+		.field("time", DataTypes.TIMESTAMP(3))
+		.field("ip", DataTypes.VARCHAR(16))
+		.field("route", DataTypes.STRING())
+		.field("date", DataTypes.STRING(), "CAST(DATE(`time`) AS STRING)")
+		.field("year", DataTypes.STRING(), "CAST(YEAR(`time`) AS STRING)")
+		.field("month", DataTypes.STRING(), "CAST(MONTH(`time`) AS STRING)")
+		.field("day", DataTypes.STRING(), "CAST(DAYOFMONTH(`time`) AS STRING)")
+		.build();
+
+	/**
+	 * A list of field delimiters to use in the tests.
+	 */
+	private static final List<String> FIELD_DELIMITERS = Arrays.asList("", "|", ",", "--");
+
+	/**
+	 * A {@code PARTITION BY(date, ip)} clause to use for the positive tests.
+	 */
+	private static final List<String> PARTITION_BY_DATE_AND_IP = Arrays.asList("date", "ip");
+
+	/**
+	 * A {@code PARTITION BY(year, month, day)} clause to use for the positive tests.
+	 */
+	private static final List<String> PARTITION_BY_DATE = Arrays.asList("year", "month", "day");
+
+	/**
+	 * A {@code PARTITION BY(route)} clause to use for the positive tests.
+	 */
+	private static final List<String> PARTITION_BY_ROUTE = Collections.singletonList("route");
+
+	/**
+	 * Some not-so-random {@link LocalDateTime} instances to use for sample {@link RowData}
+	 * elements in the tests.
+	 */
+	private static final List<LocalDateTime> DATE_TIMES = Arrays.asList(
+		LocalDateTime.of(2014, 10, 22, 12, 0),
+		LocalDateTime.of(2015, 11, 13, 10, 0),
+		LocalDateTime.of(2015, 12, 14, 14, 0),
+		LocalDateTime.of(2018, 10, 31, 15, 0));
+
+	/**
+	 * A default IP to use for sample {@link RowData} elements in the tests.
+	 */
+	private static final String IP = "255.255.255.255";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	// --------------------------------------------------------------------------------------------
+	// Positive tests
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testGoodPartitioner() {
+		CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE_AND_IP);
+
+		for (String delimiter : FIELD_DELIMITERS) {
+			RowDataFieldsKinesisPartitioner partitioner =
+				new RowDataFieldsKinesisPartitioner(table, delimiter);
+
+			for (LocalDateTime time : DATE_TIMES) {
+				String expectedKey = String.join(delimiter, String.valueOf(days(time)), IP);
+				String actualKey = partitioner.getPartitionId(createElement(time, IP));
+
+				assertEquals(expectedKey, actualKey);
+			}
+		}
+	}
+
+	@Test
+	public void testGoodPartitionerExceedingMaxLength() {
+		CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_ROUTE);
+		RowDataFieldsKinesisPartitioner partitioner = new RowDataFieldsKinesisPartitioner(table);
+
+		String ip = "255.255.255.255";
+		String route = "http://www.very-" + repeat("long-", 50) + "address.com/home";
+		String expectedKey = route.substring(0, MAX_PARTITION_KEY_LENGTH);
+
+		for (LocalDateTime time : DATE_TIMES) {
+			String actualKey = partitioner.getPartitionId(createElement(time, ip, route));
+			assertEquals(expectedKey, actualKey);
+		}
+	}
+
+	@Test
+	public void testGoodPartitionerWithStaticPrefix() {
+		CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
+
+		// fixed prefix
+		String year = String.valueOf(year(DATE_TIMES.get(0)));
+		String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
+
+		for (String delimiter : FIELD_DELIMITERS) {
+			RowDataFieldsKinesisPartitioner partitioner =
+				new RowDataFieldsKinesisPartitioner(table, delimiter);
+
+			partitioner.setStaticFields(new HashMap<String, String>() {{
+				put("year", year);
+				put("month", month);
+			}});
+
+			for (LocalDateTime time : DATE_TIMES) {
+				String day = String.valueOf(dayOfMonth(time));
+				String expectedKey = String.join(delimiter, year, month, day);
+				String actualKey = partitioner.getPartitionId(createElement(time, IP));
+
+				assertEquals(expectedKey, actualKey);
+			}
+		}
+	}
+
+	@Test
+	public void testGoodPartitionerWithStaticSuffix() {
+		CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
+
+		// fixed suffix
+		String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
+		String day = String.valueOf(dayOfMonth(DATE_TIMES.get(0)));
+
+		for (String delimiter : FIELD_DELIMITERS) {
+			RowDataFieldsKinesisPartitioner partitioner =
+				new RowDataFieldsKinesisPartitioner(table, delimiter);
+
+			partitioner.setStaticFields(new HashMap<String, String>() {{
+				put("month", month);
+				put("day", day);
+			}});
+
+			for (LocalDateTime time : DATE_TIMES) {
+				String year = String.valueOf(year(time));
+				String expectedKey = String.join(delimiter, year, month, day);
+				String actualKey = partitioner.getPartitionId(createElement(time, IP));
+
+				assertEquals(expectedKey, actualKey);
+			}
+		}
+	}
+
+	@Test
+	public void testGoodPartitionerWithStaticInfix() {
+		CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
+
+		// fixed infix
+		String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
+
+		for (String delimiter : FIELD_DELIMITERS) {
+			RowDataFieldsKinesisPartitioner partitioner =
+				new RowDataFieldsKinesisPartitioner(table, delimiter);
+
+			partitioner.setStaticFields(new HashMap<String, String>() {{
+				put("month", month);
+			}});
+
+			for (LocalDateTime time : DATE_TIMES) {
+				String year = String.valueOf(year(time));
+				String day = String.valueOf(dayOfMonth(time));
+				String expectedKey = String.join(delimiter, year, month, day);
+				String actualKey = partitioner.getPartitionId(createElement(time, IP));
+
+				assertEquals(expectedKey, actualKey);
+			}
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Negative tests
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testBadPartitionerWithEmptyPrefix() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(containsCause(new IllegalArgumentException(
+			"Cannot create a RowDataFieldsKinesisPartitioner for a non-partitioned table")));
+
+		CatalogTable table = createTable(defaultTableOptions(), Collections.emptyList());
+		new RowDataFieldsKinesisPartitioner(table);
+	}
+
+	@Test
+	public void testBadPartitionerWithDuplicatePartitionKeys() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(containsCause(new IllegalArgumentException(
+			"The sequence of partition keys cannot contain duplicates")));
+
+		CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("ip", "ip"));
+		new RowDataFieldsKinesisPartitioner(table);
+	}
+
+	@Test
+	public void testBadPartitionerWithBadFieldFieldNames() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(containsCause(new IllegalArgumentException(
+			"The following partition keys are not present in the table: abc")));
+
+		CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("ip", "abc"));
+		new RowDataFieldsKinesisPartitioner(table);
+	}
+
+	@Test
+	public void testBadPartitionerWithBadFieldFieldTypes() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(containsCause(new IllegalArgumentException(
+			"The following partition keys have types that are not supported by Kinesis: time")));
+
+		CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("time", "ip"));
+		new RowDataFieldsKinesisPartitioner(table);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Utilities
+	// --------------------------------------------------------------------------------------------
+
+	private RowData createElement(LocalDateTime time, String ip) {
+		return createElement(time, ip, "https://flink.apache.org/home");
+	}
+
+	private RowData createElement(LocalDateTime time, String ip, String route) {
+		GenericRowData element = new GenericRowData(TABLE_SCHEMA.getFieldCount());
+		element.setField(0, TimestampData.fromLocalDateTime(time));
+		element.setField(1, StringData.fromString(ip));
+		element.setField(2, StringData.fromString(route));
+		element.setField(3, StringData.fromString(String.valueOf(days(time))));
+		element.setField(4, StringData.fromString(String.valueOf(year(time))));
+		element.setField(5, StringData.fromString(String.valueOf(monthOfYear(time))));
+		element.setField(6, StringData.fromString(String.valueOf(dayOfMonth(time))));
+		return element;
+	}
+
+	private int days(LocalDateTime time) {
+		return (int) ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), time);
+	}
+
+	private int year(LocalDateTime time) {
+		return time.get(ChronoField.YEAR);
+	}
+
+	private int monthOfYear(LocalDateTime time) {
+		return time.get(ChronoField.MONTH_OF_YEAR);
+	}
+
+	private int dayOfMonth(LocalDateTime time) {
+		return time.get(ChronoField.DAY_OF_MONTH);
+	}
+
+	private CatalogTable createTable(TableOptionsBuilder options, List<String> partitionKeys) {
+		return new CatalogTableImpl(TABLE_SCHEMA, partitionKeys, options.build(), TABLE_NAME);
+	}
+
+	private TableOptionsBuilder defaultTableOptions() {
+		String connector = KinesisDynamicTableFactory.IDENTIFIER;
+		String format = TestFormatFactory.IDENTIFIER;
+		return new TableOptionsBuilder(connector, format)
+			// default table options
+			.withTableOption(KinesisOptions.STREAM, TABLE_NAME)
+			.withTableOption("properties.aws.region", "us-west-2")
+			// default format options
+			.withFormatOption(TestFormatFactory.DELIMITER, ",");
+	}
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisBehavioursFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisBehavioursFactory.java
@@ -46,6 +46,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static software.amazon.kinesis.connectors.flink.testutils.TestUtils.createDummyStreamShardHandle;
 
 /**
  * Factory for different kinds of fake Kinesis behaviours using the {@link KinesisProxyInterface} interface.
@@ -91,27 +92,27 @@ public class FakeKinesisBehavioursFactory {
 	}
 
 	public static KinesisProxyInterface totalNumOfRecordsAfterNumOfGetRecordsCalls(
-		final int numOfRecords,
-		final int numOfGetRecordsCalls,
-		final long millisBehindLatest) {
+			final int numOfRecords,
+			final int numOfGetRecordsCalls,
+			final long millisBehindLatest) {
 		return new SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls, millisBehindLatest);
 	}
 
 	public static KinesisProxyInterface totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(
-		final int numOfRecords,
-		final int numOfGetRecordsCall,
-		final int orderOfCallToExpire,
-		final long millisBehindLatest) {
+			final int numOfRecords,
+			final int numOfGetRecordsCall,
+			final int orderOfCallToExpire,
+			final long millisBehindLatest) {
 		return new SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(
 			numOfRecords, numOfGetRecordsCall, orderOfCallToExpire, millisBehindLatest);
 	}
 
 	public static KinesisProxyInterface initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(
-		final int numOfRecords,
-		final int numOfGetRecordsCalls,
-		final long millisBehindLatest) {
+			final int numOfRecords,
+			final int numOfGetRecordsCalls,
+			final long millisBehindLatest) {
 		return new SingleShardEmittingAdaptiveNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls,
-			millisBehindLatest);
+				millisBehindLatest);
 	}
 
 	/**
@@ -153,8 +154,8 @@ public class FakeKinesisBehavioursFactory {
 		@Override
 		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) throws InterruptedException {
 			return new GetRecordsResult()
-					.withMillisBehindLatest(0L)
-					.withNextShardIterator(remainingIterators == 0 ? null : String.valueOf(remainingIterators--));
+				.withMillisBehindLatest(0L)
+				.withNextShardIterator(remainingIterators == 0 ? null : String.valueOf(remainingIterators--));
 		}
 
 		@Override
@@ -172,10 +173,10 @@ public class FakeKinesisBehavioursFactory {
 		private boolean expiredIteratorRefreshed = false;
 
 		public SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(
-			final int numOfRecords,
-			final int numOfGetRecordsCalls,
-			final int orderOfCallToExpire,
-			final long millisBehindLatest) {
+				final int numOfRecords,
+				final int numOfGetRecordsCalls,
+				final int orderOfCallToExpire,
+				final long millisBehindLatest) {
 			super(numOfRecords, numOfGetRecordsCalls, millisBehindLatest);
 			checkArgument(orderOfCallToExpire <= numOfGetRecordsCalls,
 				"can not test unexpected expired iterator if orderOfCallToExpire is larger than numOfGetRecordsCalls");
@@ -229,9 +230,9 @@ public class FakeKinesisBehavioursFactory {
 		protected final Map<String, List<Record>> shardItrToRecordBatch;
 
 		public SingleShardEmittingFixNumOfRecordsKinesis(
-			final int numOfRecords,
-			final int numOfGetRecordsCalls,
-			final long millistBehindLatest) {
+				final int numOfRecords,
+				final int numOfGetRecordsCalls,
+				final long millistBehindLatest) {
 			this.totalNumOfRecords = numOfRecords;
 			this.totalNumOfGetRecordsCalls = numOfGetRecordsCalls;
 			this.millisBehindLatest = millistBehindLatest;
@@ -304,15 +305,15 @@ public class FakeKinesisBehavioursFactory {
 		private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
 
 		public SingleShardEmittingAdaptiveNumOfRecordsKinesis(
-			final int numOfRecords,
-			final int numOfGetRecordsCalls,
-			final long millisBehindLatest) {
+				final int numOfRecords,
+				final int numOfGetRecordsCalls,
+				final long millisBehindLatest) {
 			super(initShardItrToRecordBatch(numOfRecords, numOfGetRecordsCalls), millisBehindLatest);
 		}
 
 		private static Map<String, List<Record>> initShardItrToRecordBatch(
-			final int numOfRecords,
-			final int numOfGetRecordsCalls) {
+				final int numOfRecords,
+				final int numOfGetRecordsCalls) {
 			// initialize the record batches that we will be fetched
 			Map<String, List<Record>> shardItrToRecordBatch = new HashMap<>();
 
@@ -341,11 +342,11 @@ public class FakeKinesisBehavioursFactory {
 
 			for (int i = min; i < max; i++) {
 				Record record = new Record()
-					.withData(
-						ByteBuffer.wrap(data.getBytes(ConfigConstants.DEFAULT_CHARSET)))
-					.withPartitionKey(UUID.randomUUID().toString())
-					.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
-					.withSequenceNumber(String.valueOf(i));
+								.withData(
+										ByteBuffer.wrap(data.getBytes(ConfigConstants.DEFAULT_CHARSET)))
+								.withPartitionKey(UUID.randomUUID().toString())
+								.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
+								.withSequenceNumber(String.valueOf(i));
 				batch.add(record);
 				sumRecordBatchBytes += record.getData().remaining();
 
@@ -366,7 +367,7 @@ public class FakeKinesisBehavioursFactory {
 	private static class SingleShardEmittingAggregatedRecordsKinesis extends SingleShardEmittingKinesis {
 
 		public SingleShardEmittingAggregatedRecordsKinesis(
-			final int numOfAggregatedRecords,
+				final int numOfAggregatedRecords,
 			final int numOfChildRecords,
 			final int numOfGetRecordsCalls) {
 			super(initShardItrToRecordBatch(numOfAggregatedRecords, numOfChildRecords, numOfGetRecordsCalls));
@@ -447,9 +448,7 @@ public class FakeKinesisBehavioursFactory {
 					List<StreamShardHandle> shardsOfStream = new ArrayList<>(shardCount);
 					for (int i = 0; i < shardCount; i++) {
 						shardsOfStream.add(
-							new StreamShardHandle(
-								streamName,
-								new Shard().withShardId(KinesisShardIdGenerator.generateFromShardOrder(i))));
+							createDummyStreamShardHandle(streamName, KinesisShardIdGenerator.generateFromShardOrder(i)));
 					}
 					streamsWithListOfShards.put(streamName, shardsOfStream);
 				}
@@ -582,7 +581,7 @@ public class FakeKinesisBehavioursFactory {
 		@Override
 		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
 			BlockingQueue<String> queue = Preconditions.checkNotNull(this.shardIteratorToQueueMap.get(shardIterator),
-				"no queue for iterator %s", shardIterator);
+			"no queue for iterator %s", shardIterator);
 			List<Record> records = Collections.emptyList();
 			try {
 				String data = queue.take();

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/KinesisPubsubClient.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/KinesisPubsubClient.java
@@ -1,0 +1,131 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.testutils;
+
+import org.apache.flink.api.common.time.Deadline;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
+import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
+import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
+import software.amazon.kinesis.connectors.flink.proxy.GetShardListResult;
+import software.amazon.kinesis.connectors.flink.proxy.KinesisProxy;
+import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyInterface;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Simple client to publish and retrieve messages, using the AWS Kinesis SDK and the
+ * Flink Kinesis Connectos classes.
+ */
+public class KinesisPubsubClient {
+	private static final Logger LOG = LoggerFactory.getLogger(KinesisPubsubClient.class);
+
+	private final AmazonKinesis kinesisClient;
+	private final Properties properties;
+
+	public KinesisPubsubClient(Properties properties) {
+		this.kinesisClient = createClientWithCredentials(properties);
+		this.properties = properties;
+	}
+
+	public void createTopic(String stream, int shards, Properties props) throws Exception {
+		try {
+			kinesisClient.describeStream(stream);
+			kinesisClient.deleteStream(stream);
+		} catch (ResourceNotFoundException rnfe) {
+			// expected when stream doesn't exist
+		}
+
+		kinesisClient.createStream(stream, shards);
+		Deadline deadline  = Deadline.fromNow(Duration.ofSeconds(5));
+		while (deadline.hasTimeLeft()) {
+			try {
+				Thread.sleep(250); // sleep for a bit for stream to be created
+				if (kinesisClient.describeStream(stream).getStreamDescription()
+					.getShards().size() != shards) {
+					// not fully created yet
+					continue;
+				}
+				break;
+			} catch (ResourceNotFoundException rnfe) {
+				// not ready yet
+			}
+		}
+	}
+
+	public void sendMessage(String topic, String msg) {
+		PutRecordRequest putRecordRequest = new PutRecordRequest();
+		putRecordRequest.setStreamName(topic);
+		putRecordRequest.setPartitionKey("fakePartitionKey");
+		putRecordRequest.withData(ByteBuffer.wrap(msg.getBytes()));
+		PutRecordResult putRecordResult = kinesisClient.putRecord(putRecordRequest);
+		LOG.info("added record: {}", putRecordResult.getSequenceNumber());
+	}
+
+	public List<String> readAllMessages(String streamName) throws Exception {
+		KinesisProxyInterface kinesisProxy = KinesisProxy.create(properties);
+		Map<String, String> streamNamesWithLastSeenShardIds = new HashMap<>();
+		streamNamesWithLastSeenShardIds.put(streamName, null);
+
+		GetShardListResult shardListResult = kinesisProxy.getShardList(streamNamesWithLastSeenShardIds);
+		int maxRecordsToFetch = 10;
+
+		List<String> messages = new ArrayList<>();
+		// retrieve records from all shards
+		for (StreamShardHandle ssh : shardListResult.getRetrievedShardListOfStream(streamName)) {
+			String shardIterator = kinesisProxy.getShardIterator(ssh, "TRIM_HORIZON", null);
+			GetRecordsResult getRecordsResult = kinesisProxy.getRecords(shardIterator, maxRecordsToFetch);
+			List<Record> aggregatedRecords = getRecordsResult.getRecords();
+			for (Record record : aggregatedRecords) {
+				messages.add(new String(record.getData().array()));
+			}
+		}
+		return messages;
+	}
+
+	private static AmazonKinesis createClientWithCredentials(Properties props) throws AmazonClientException {
+		AWSCredentialsProvider credentialsProvider = new EnvironmentVariableCredentialsProvider();
+		return AmazonKinesisClientBuilder.standard()
+			.withCredentials(credentialsProvider)
+			.withEndpointConfiguration(
+				new AwsClientBuilder.EndpointConfiguration(
+					props.getProperty(ConsumerConfigConstants.AWS_ENDPOINT), "us-east-1"))
+			.build();
+	}
+
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TableOptionsBuilder.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TableOptionsBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.testutils;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Convenience syntax for constructing option maps for testing
+ * {@link org.apache.flink.table.factories.DynamicTableFactory} implementations.
+ * <p>Back-ported from Flink upstream, branch 1.12.0-rc3, `org.apache.flink.table.factories.TableOptionsBuilder`.</p>
+ */
+public class TableOptionsBuilder {
+	private final Map<String, String> options;
+	private final String connector;
+	private final String format;
+
+	public TableOptionsBuilder(String connector, String format) {
+		this.options = new HashMap<>();
+		this.connector = connector;
+		this.format = format;
+	}
+
+	public TableOptionsBuilder withTableOption(ConfigOption<?> option, String value) {
+		return withTableOption(option.key(), value);
+	}
+
+	public TableOptionsBuilder withFormatOption(ConfigOption<?> option, String value) {
+		return withFormatOption(format + "." + option.key(), value);
+	}
+
+	public TableOptionsBuilder withTableOption(String key, String value) {
+		options.put(key, value);
+		return this;
+	}
+
+	public TableOptionsBuilder withFormatOption(String key, String value) {
+		options.put(key, value);
+		return this;
+	}
+
+	public Map<String, String> build() {
+		withTableOption(FactoryUtil.CONNECTOR, connector);
+		withTableOption(FactoryUtil.FORMAT, format);
+		return options;
+	}
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestFormatFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestFormatFactory.java
@@ -1,0 +1,231 @@
+/*
+ * This file has been modified from the original.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.testutils;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Tests implementations for
+ * {@link org.apache.flink.table.factories.DeserializationFormatFactory} and
+ * {@link org.apache.flink.table.factories.SerializationFormatFactory}.
+ */
+public class TestFormatFactory implements DeserializationFormatFactory, SerializationFormatFactory {
+
+	public static final String IDENTIFIER = "kinesis-test-format";
+
+	public static final ConfigOption<String> DELIMITER = ConfigOptions
+			.key("delimiter")
+			.stringType()
+			.noDefaultValue();
+
+	public static final ConfigOption<Boolean> FAIL_ON_MISSING = ConfigOptions
+			.key("fail-on-missing")
+			.booleanType()
+			.defaultValue(false);
+
+	@Override
+	public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+			DynamicTableFactory.Context context,
+			ReadableConfig formatConfig) {
+		FactoryUtil.validateFactoryOptions(this, formatConfig);
+		return new DecodingFormatMock(formatConfig.get(DELIMITER), formatConfig.get(FAIL_ON_MISSING));
+	}
+
+	@Override
+	public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+			DynamicTableFactory.Context context,
+			ReadableConfig formatConfig) {
+		FactoryUtil.validateFactoryOptions(this, formatConfig);
+		return new EncodingFormatMock(formatConfig.get(DELIMITER));
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		final Set<ConfigOption<?>> options = new HashSet<>();
+		options.add(DELIMITER);
+		return options;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		final Set<ConfigOption<?>> options = new HashSet<>();
+		options.add(FAIL_ON_MISSING);
+		return options;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Table source format & deserialization schema
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * {@link DecodingFormat} for testing.
+	 */
+	public static class DecodingFormatMock implements DecodingFormat<DeserializationSchema<RowData>> {
+
+		public final String delimiter;
+		public final Boolean failOnMissing;
+
+		public DecodingFormatMock(String delimiter, Boolean failOnMissing) {
+			this.delimiter = delimiter;
+			this.failOnMissing = failOnMissing;
+		}
+
+		@Override
+		public DeserializationSchema<RowData> createRuntimeDecoder(
+				DynamicTableSource.Context context,
+				DataType producedDataType) {
+			return new DeserializationSchemaMock(
+					(TypeInformation<RowData>) context.createTypeInformation(producedDataType));
+		}
+
+		@Override
+		public ChangelogMode getChangelogMode() {
+			return null;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			DecodingFormatMock that = (DecodingFormatMock) o;
+			return delimiter.equals(that.delimiter)
+					&& failOnMissing.equals(that.failOnMissing);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(delimiter, failOnMissing);
+		}
+	}
+
+	/**
+	 * {@link DeserializationSchema} for testing.
+	 */
+	private static class DeserializationSchemaMock implements DeserializationSchema<RowData> {
+
+		private final TypeInformation<RowData> producedTypeInfo;
+
+		private DeserializationSchemaMock(TypeInformation<RowData> producedTypeInfo) {
+			this.producedTypeInfo = producedTypeInfo;
+		}
+
+		@Override
+		public RowData deserialize(byte[] message) {
+			String msg = "Test deserialization schema doesn't support deserialize.";
+			throw new UnsupportedOperationException(msg);
+		}
+
+		@Override
+		public boolean isEndOfStream(RowData nextElement) {
+			return false;
+		}
+
+		@Override
+		public TypeInformation<RowData> getProducedType() {
+			return producedTypeInfo;
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Table sink format & serialization schema
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * {@link EncodingFormat} for testing.
+	 */
+	public static class EncodingFormatMock implements EncodingFormat<SerializationSchema<RowData>> {
+
+		public final String delimiter;
+
+		public EncodingFormatMock(String delimiter) {
+			this.delimiter = delimiter;
+		}
+
+		@Override
+		public SerializationSchema<RowData> createRuntimeEncoder(
+				DynamicTableSink.Context context,
+				DataType physicalDataType) {
+			return new SerializationSchemaMock();
+		}
+
+		@Override
+		public ChangelogMode getChangelogMode() {
+			return null;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			EncodingFormatMock that = (EncodingFormatMock) o;
+			return delimiter.equals(that.delimiter);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(delimiter);
+		}
+	}
+
+	/**
+	 * {@link SerializationSchema} for testing.
+	 */
+	private static class SerializationSchemaMock implements SerializationSchema<RowData> {
+		@Override
+		public byte[] serialize(RowData element) {
+			String msg = "Test serialization schema doesn't support serialize.";
+			throw new UnsupportedOperationException(msg);
+		}
+	}
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestRuntimeContext.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestRuntimeContext.java
@@ -49,7 +49,7 @@ public class TestRuntimeContext extends StreamingRuntimeContext {
 			new TestStreamOperator(),
 			new MockEnvironmentBuilder()
 				.setTaskName("mockTask")
-				.setMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
+				.setManagedMemorySize(4 * MemoryManager.DEFAULT_PAGE_SIZE)
 				.build(),
 			Collections.emptyMap());
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
@@ -31,7 +31,6 @@ import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.kinesis.connectors.flink.config.AWSConfigConstants;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordBatch;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
 import software.amazon.kinesis.connectors.flink.model.SequenceNumber;
@@ -45,6 +44,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFORegistrationType.NONE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
 
 /**
  * General test utils.
@@ -125,9 +130,9 @@ public class TestUtils {
 
 	public static Properties efoProperties() {
 		Properties consumerConfig = new Properties();
-		consumerConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.name());
-		consumerConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, ConsumerConfigConstants.EFORegistrationType.NONE.name());
-		consumerConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + "fakeStream", "stream-consumer-arn");
+		consumerConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		consumerConfig.setProperty(EFO_REGISTRATION_TYPE, NONE.name());
+		consumerConfig.setProperty(EFO_CONSUMER_ARN_PREFIX + "." + "fakeStream", "stream-consumer-arn");
 		return consumerConfig;
 	}
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/util/RecordEmitterTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/util/RecordEmitterTest.java
@@ -19,12 +19,14 @@
 
 package software.amazon.kinesis.connectors.flink.util;
 
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,9 +36,9 @@ import java.util.concurrent.Executors;
 /** Test for {@link RecordEmitter}. */
 public class RecordEmitterTest {
 
-	static List<TimestampedValue> results = Collections.synchronizedList(new ArrayList<>());
-
 	private class TestRecordEmitter extends RecordEmitter<TimestampedValue> {
+
+		private List<TimestampedValue> results = Collections.synchronizedList(new ArrayList<>());
 
 		private TestRecordEmitter() {
 			super(DEFAULT_QUEUE_CAPACITY);
@@ -70,14 +72,66 @@ public class RecordEmitterTest {
 		ExecutorService executor = Executors.newSingleThreadExecutor();
 		executor.submit(emitter);
 
-		long timeout = System.currentTimeMillis() + 10_000;
-		while (results.size() != 4 && System.currentTimeMillis() < timeout) {
-			Thread.sleep(100);
+		Deadline dl = Deadline.fromNow(Duration.ofSeconds(10));
+		while (emitter.results.size() != 4 && dl.hasTimeLeft()) {
+			Thread.sleep(10);
 		}
 		emitter.stop();
 		executor.shutdownNow();
 
-		Assert.assertThat(results, Matchers.contains(one, five, two, ten));
+		Assert.assertThat(emitter.results, Matchers.contains(one, five, two, ten));
 	}
 
+	@Test
+	public void testRetainMinAfterReachingLimit() throws Exception {
+
+		TestRecordEmitter emitter = new TestRecordEmitter();
+
+		final TimestampedValue<String> one = new TimestampedValue<>("1", 1);
+		final TimestampedValue<String> two = new TimestampedValue<>("2", 2);
+		final TimestampedValue<String> three = new TimestampedValue<>("3", 3);
+		final TimestampedValue<String> ten = new TimestampedValue<>("10", 10);
+		final TimestampedValue<String> eleven = new TimestampedValue<>("11", 11);
+
+		final TimestampedValue<String> twenty = new TimestampedValue<>("20", 20);
+		final TimestampedValue<String> thirty = new TimestampedValue<>("30", 30);
+
+		final RecordEmitter.RecordQueue<TimestampedValue> queue0 = emitter.getQueue(0);
+		final RecordEmitter.RecordQueue<TimestampedValue> queue1 = emitter.getQueue(1);
+
+		queue0.put(one);
+		queue0.put(two);
+		queue0.put(three);
+		queue0.put(ten);
+		queue0.put(eleven);
+
+		queue1.put(twenty);
+		queue1.put(thirty);
+
+		emitter.setMaxLookaheadMillis(1);
+		emitter.setCurrentWatermark(5);
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		executor.submit(emitter);
+		try {
+			// emits one record past the limit
+			Deadline dl = Deadline.fromNow(Duration.ofSeconds(10));
+			while (emitter.results.size() != 4 && dl.hasTimeLeft()) {
+				Thread.sleep(10);
+			}
+			Assert.assertThat(emitter.results, Matchers.contains(one, two, three, ten));
+
+			// advance watermark, emits remaining record from queue0
+			emitter.setCurrentWatermark(10);
+			dl = Deadline.fromNow(Duration.ofSeconds(10));
+			while (emitter.results.size() != 5 && dl.hasTimeLeft()) {
+				Thread.sleep(10);
+			}
+			Assert.assertThat(emitter.results, Matchers.contains(one, two, three, ten, eleven));
+		}
+		finally {
+			emitter.stop();
+			executor.shutdownNow();
+		}
+	}
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
@@ -20,7 +20,6 @@
 package software.amazon.kinesis.connectors.flink.util;
 
 import org.junit.Test;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.StreamConsumerRegistrar;
 
 import java.util.Arrays;
@@ -31,6 +30,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.efoConsumerArn;
 
 /**
  * Tests for {@link StreamConsumerRegistrar}.
@@ -40,7 +43,7 @@ public class StreamConsumerRegistrarUtilTest {
 	@Test
 	public void testRegisterStreamConsumers() throws Exception {
 		Properties configProps = new Properties();
-		configProps.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "consumer-name");
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
 
 		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
 		when(registrar.registerStreamConsumer("stream-1", "consumer-name"))
@@ -50,15 +53,15 @@ public class StreamConsumerRegistrarUtilTest {
 
 		StreamConsumerRegistrarUtil.registerStreamConsumers(registrar, configProps, Arrays.asList("stream-1", "stream-2"));
 
-		assertEquals("stream-1-consumer-arn", configProps.getProperty(ConsumerConfigConstants.efoConsumerArn("stream-1")));
-		assertEquals("stream-2-consumer-arn", configProps.getProperty(ConsumerConfigConstants.efoConsumerArn("stream-2")));
+		assertEquals("stream-1-consumer-arn", configProps.getProperty(efoConsumerArn("stream-1")));
+		assertEquals("stream-2-consumer-arn", configProps.getProperty(efoConsumerArn("stream-2")));
 	}
 
 	@Test
 	public void testDeregisterStreamConsumersMissingStreamArn() throws Exception {
 		Properties configProps = new Properties();
-		configProps.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.name());
-		configProps.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "consumer-name");
+		configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
 
 		List<String> streams = Arrays.asList("stream-1", "stream-2");
 		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);

--- a/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+software.amazon.kinesis.connectors.flink.testutils.TestFormatFactory

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -16,12 +16,14 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=INFO, testlogger
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
 
-log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
-log4j.appender.testlogger.target = System.err
-log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
-log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
 
-# suppress the irrelevant (wrong) warnings from the netty channel handler
-log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger


### PR DESCRIPTION
*Description of changes:*

Backports the code from [the upstream `release-1.12.0-rc3` tag](https://github.com/apache/flink/tree/release-1.12.0-rc3) and bumps up the local Flink version to 1.11. This includes the upstream functionality added in [FLINK-18858: Kinesis Flink SQL Connector](https://issues.apache.org/jira/browse/FLINK-18858).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
