### PR TITLE
Migrate from DescribeStream to DescribeStreamSummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Release 1.1.0 (TBD)
 * Migrate EFO consumers to use `DescribeStreamSummary` rather than `DescribeStream`. `DescribeStreamSummary` has a 
 higher TPS quota, resulting in reduced startup time for high parallelism sources. You may need add IAM permission for 
-`kinesis:DescribeStreamSummary` while upgrading to this version.   
+`kinesis:DescribeStreamSummary` while upgrading to this version 
+ ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/10))
 
 ## Release 1.0.4 (November 11th, 2020)
 * Fix issue when Polling consumer using timestamp with empty shard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Release 1.1.0 (TBD)
+* Migrate EFO consumers to use `DescribeStreamSummary` rather than `DescribeStream`. `DescribeStreamSummary` has a 
+higher TPS quota, resulting in reduced startup time for high parallelism sources. You may need add IAM permission for 
+`kinesis:DescribeStreamSummary` while upgrading to this version.   
+
 ## Release 1.0.4 (November 11th, 2020)
 * Fix issue when Polling consumer using timestamp with empty shard
   ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/6))

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note the additional IAM permissions required to use EFO:
   "Sid": "Stream",
   "Effect": "Allow",
   "Action": [
-    "kinesis:DescribeStream",
+    "kinesis:DescribeStreamSummary",
     "kinesis:RegisterStreamConsumer",
     "kinesis:DeregisterStreamConsumer"
   ],

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/StreamConsumerRegistrar.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/StreamConsumerRegistrar.java
@@ -26,7 +26,7 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.kinesis.connectors.flink.FlinkKinesisException.FlinkKinesisTimeoutException;
@@ -88,8 +88,8 @@ public class StreamConsumerRegistrar {
 			registrationBackoff(configuration, backoff, attempt++);
 		}
 
-		DescribeStreamResponse describeStreamResponse = kinesisProxyV2Interface.describeStream(stream);
-		String streamArn = describeStreamResponse.streamDescription().streamARN();
+		DescribeStreamSummaryResponse describeStreamSummaryResponse = kinesisProxyV2Interface.describeStreamSummary(stream);
+		String streamArn = describeStreamSummaryResponse.streamDescriptionSummary().streamARN();
 
 		LOG.debug("Found stream ARN - {}", streamArn);
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2.java
@@ -29,8 +29,8 @@ import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerReq
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerRequest;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
@@ -93,14 +93,14 @@ public class KinesisProxyV2 implements KinesisProxyV2Interface {
 	}
 
 	@Override
-	public DescribeStreamResponse describeStream(String stream) throws InterruptedException, ExecutionException {
-		DescribeStreamRequest describeStreamRequest = DescribeStreamRequest
+	public DescribeStreamSummaryResponse describeStreamSummary(String stream) throws InterruptedException, ExecutionException {
+		DescribeStreamSummaryRequest describeStreamRequest = DescribeStreamSummaryRequest
 			.builder()
 			.streamName(stream)
 			.build();
 
 		return invokeWithRetryAndBackoff(
-			() -> kinesisAsyncClient.describeStream(describeStreamRequest).get(),
+			() -> kinesisAsyncClient.describeStreamSummary(describeStreamRequest).get(),
 			fanOutRecordPublisherConfiguration.getDescribeStreamBaseBackoffMillis(),
 			fanOutRecordPublisherConfiguration.getDescribeStreamMaxBackoffMillis(),
 			fanOutRecordPublisherConfiguration.getDescribeStreamExpConstant(),

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Interface.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Interface.java
@@ -23,7 +23,7 @@ import org.apache.flink.annotation.Internal;
 
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutionException;
 @Internal
 public interface KinesisProxyV2Interface {
 
-	DescribeStreamResponse describeStream(String stream) throws InterruptedException, ExecutionException;
+	DescribeStreamSummaryResponse describeStreamSummary(String stream) throws InterruptedException, ExecutionException;
 
 	DescribeStreamConsumerResponse describeStreamConsumer(final String streamConsumerArn) throws InterruptedException, ExecutionException;
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Test.java
@@ -29,8 +29,8 @@ import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerReq
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerRequest;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
@@ -251,36 +251,36 @@ public class KinesisProxyV2Test {
 	}
 
 	@Test
-	public void testDescribeStream() throws Exception {
+	public void testDescribeStreamSummary() throws Exception {
 		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
 		KinesisProxyV2 proxy = new KinesisProxyV2(client, mock(SdkAsyncHttpClient.class), createConfiguration(), mock(FullJitterBackoff.class));
 
-		DescribeStreamResponse expected = DescribeStreamResponse.builder().build();
+		DescribeStreamSummaryResponse expected = DescribeStreamSummaryResponse.builder().build();
 
-		ArgumentCaptor<DescribeStreamRequest> requestCaptor = ArgumentCaptor
-			.forClass(DescribeStreamRequest.class);
-		when(client.describeStream(requestCaptor.capture()))
+		ArgumentCaptor<DescribeStreamSummaryRequest> requestCaptor = ArgumentCaptor
+			.forClass(DescribeStreamSummaryRequest.class);
+		when(client.describeStreamSummary(requestCaptor.capture()))
 			.thenReturn(CompletableFuture.completedFuture(expected));
 
-		DescribeStreamResponse actual = proxy.describeStream("stream");
+		DescribeStreamSummaryResponse actual = proxy.describeStreamSummary("stream");
 
 		assertEquals(expected, actual);
 
-		DescribeStreamRequest request = requestCaptor.getValue();
+		DescribeStreamSummaryRequest request = requestCaptor.getValue();
 		assertEquals("stream", request.streamName());
 	}
 
 	@Test
-	public void testDescribeStreamBackoffJitter() throws Exception {
+	public void testDescribeStreamSummaryBackoffJitter() throws Exception {
 		FullJitterBackoff backoff = mock(FullJitterBackoff.class);
 		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
 		KinesisProxyV2 proxy = new KinesisProxyV2(client, mock(SdkAsyncHttpClient.class), createConfiguration(), backoff);
 
-		when(client.describeStream(any(DescribeStreamRequest.class)))
+		when(client.describeStreamSummary(any(DescribeStreamSummaryRequest.class)))
 			.thenThrow(new RuntimeException(LimitExceededException.builder().build()))
-			.thenReturn(CompletableFuture.completedFuture(DescribeStreamResponse.builder().build()));
+			.thenReturn(CompletableFuture.completedFuture(DescribeStreamSummaryResponse.builder().build()));
 
-		proxy.describeStream("arn");
+		proxy.describeStreamSummary("arn");
 
 		verify(backoff).sleep(anyLong());
 		verify(backoff).calculateFullJitterBackoff(
@@ -291,7 +291,7 @@ public class KinesisProxyV2Test {
 	}
 
 	@Test
-	public void testDescribeStreamFailsAfterMaxRetries() throws Exception {
+	public void testDescribeStreamSummaryFailsAfterMaxRetries() throws Exception {
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("Retries exceeded - all 10 retry attempts failed.");
 
@@ -299,10 +299,10 @@ public class KinesisProxyV2Test {
 		KinesisAsyncClient client = mock(KinesisAsyncClient.class);
 		KinesisProxyV2 proxy = new KinesisProxyV2(client, mock(SdkAsyncHttpClient.class), createConfiguration(), backoff);
 
-		when(client.describeStream(any(DescribeStreamRequest.class)))
+		when(client.describeStreamSummary(any(DescribeStreamSummaryRequest.class)))
 			.thenThrow(new RuntimeException(LimitExceededException.builder().build()));
 
-		proxy.describeStream("arn");
+		proxy.describeStreamSummary("arn");
 	}
 
 	private FanOutRecordPublisherConfiguration createConfiguration() {

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -28,13 +28,13 @@ import software.amazon.awssdk.services.kinesis.model.ConsumerDescription;
 import software.amazon.awssdk.services.kinesis.model.ConsumerStatus;
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerResponse;
-import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamSummaryResponse;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.services.kinesis.model.Record;
 import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerResponse;
 import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.StartingPosition;
-import software.amazon.awssdk.services.kinesis.model.StreamDescription;
+import software.amazon.awssdk.services.kinesis.model.StreamDescriptionSummary;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEventStream;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
@@ -429,14 +429,14 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		@Override
-		public DescribeStreamResponse describeStream(String stream) throws InterruptedException, ExecutionException {
+		public DescribeStreamSummaryResponse describeStreamSummary(String stream) throws InterruptedException, ExecutionException {
 			if (throwsWhileDescribingStream != null) {
 				throw throwsWhileDescribingStream;
 			}
 
-			return DescribeStreamResponse
+			return DescribeStreamSummaryResponse
 				.builder()
-				.streamDescription(StreamDescription
+				.streamDescriptionSummary(StreamDescriptionSummary
 					.builder()
 					.streamARN(STREAM_ARN)
 					.build())
@@ -533,7 +533,7 @@ public class FakeKinesisFanOutBehavioursFactory {
 	private static class KinesisProxyV2InterfaceAdapter implements KinesisProxyV2Interface {
 
 		@Override
-		public DescribeStreamResponse describeStream(String stream) throws InterruptedException, ExecutionException {
+		public DescribeStreamSummaryResponse describeStreamSummary(String stream) throws InterruptedException, ExecutionException {
 			throw new UnsupportedOperationException("This method is not implemented.");
 		}
 


### PR DESCRIPTION
*Description of changes:*
Migrate EFO consumers to use `DescribeStreamSummary` rather than `DescribeStream`. `DescribeStreamSummary` has a 
higher TPS quota, resulting in reduced startup time for high parallelism sources. You may need add IAM permission for 
`kinesis:DescribeStreamSummary` while upgrading to this version.   


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
