### PR TITLE
Fix issue preventing DynamoDB stream consumers to start from `LATEST`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 higher TPS quota, resulting in reduced startup time for high parallelism sources. You may need add IAM permission for 
 `kinesis:DescribeStreamSummary` while upgrading to this version 
  ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/10))
+ 
+* Fix issue preventing DynamoDB stream consumers to start from `LATEST` 
+  ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/11), 
+  [issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/9))
 
 ## Release 1.0.4 (November 11th, 2020)
 * Fix issue when Polling consumer using timestamp with empty shard

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
@@ -10,6 +10,8 @@ import software.amazon.kinesis.connectors.flink.serialization.KinesisDeserializa
 import software.amazon.kinesis.connectors.flink.testutils.TestSourceContext;
 import software.amazon.kinesis.connectors.flink.testutils.TestUtils;
 
+import java.util.Properties;
+
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
@@ -23,7 +25,7 @@ import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNum
 public class DynamoDBStreamsDataFetcherTest {
 
 	@Test
-	public void testCreateShardConsumerRespectsShardIteratorTypeLatest() throws Exception {
+	public void testCreateRecordPublisherRespectsShardIteratorTypeLatest() throws Exception {
 		RuntimeContext runtimeContext = TestUtils.getMockedRuntimeContext(1, 0);
 		KinesisProxyInterface kinesis = mock(KinesisProxyInterface.class);
 
@@ -38,7 +40,11 @@ public class DynamoDBStreamsDataFetcherTest {
 
 		StreamShardHandle dummyStreamShardHandle = TestUtils.createDummyStreamShardHandle("dummy-stream", "0");
 
-		fetcher.createShardConsumer(0, dummyStreamShardHandle, SENTINEL_LATEST_SEQUENCE_NUM.get(), runtimeContext.getMetricGroup());
+		fetcher.createRecordPublisher(
+				SENTINEL_LATEST_SEQUENCE_NUM.get(),
+				new Properties(),
+				runtimeContext.getMetricGroup(),
+				dummyStreamShardHandle);
 
 		verify(kinesis).getShardIterator(dummyStreamShardHandle, LATEST.toString(), null);
 	}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
@@ -1,0 +1,46 @@
+package software.amazon.kinesis.connectors.flink.internals;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+
+import org.junit.Test;
+import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
+import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyInterface;
+import software.amazon.kinesis.connectors.flink.serialization.KinesisDeserializationSchemaWrapper;
+import software.amazon.kinesis.connectors.flink.testutils.TestSourceContext;
+import software.amazon.kinesis.connectors.flink.testutils.TestUtils;
+
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
+
+/**
+ * Tests for {@link DynamoDBStreamsDataFetcher}.
+ */
+public class DynamoDBStreamsDataFetcherTest {
+
+	@Test
+	public void testCreateShardConsumerRespectsShardIteratorTypeLatest() throws Exception {
+		RuntimeContext runtimeContext = TestUtils.getMockedRuntimeContext(1, 0);
+		KinesisProxyInterface kinesis = mock(KinesisProxyInterface.class);
+
+		DynamoDBStreamsDataFetcher<String> fetcher = new DynamoDBStreamsDataFetcher<>(
+				singletonList("fakeStream"),
+				new TestSourceContext<>(),
+				runtimeContext,
+				TestUtils.getStandardProperties(),
+				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+				DEFAULT_SHARD_ASSIGNER,
+				config -> kinesis);
+
+		StreamShardHandle dummyStreamShardHandle = TestUtils.createDummyStreamShardHandle("dummy-stream", "0");
+
+		fetcher.createShardConsumer(0, dummyStreamShardHandle, SENTINEL_LATEST_SEQUENCE_NUM.get(), runtimeContext.getMetricGroup());
+
+		verify(kinesis).getShardIterator(dummyStreamShardHandle, LATEST.toString(), null);
+	}
+
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
@@ -19,7 +19,9 @@
 
 package software.amazon.kinesis.connectors.flink.testutils;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import com.amazonaws.kinesis.agg.AggRecord;
 import com.amazonaws.kinesis.agg.RecordAggregator;
@@ -30,6 +32,7 @@ import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.mockito.Mockito;
 import software.amazon.kinesis.connectors.flink.config.AWSConfigConstants;
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordBatch;
@@ -45,6 +48,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * General test utils.
@@ -131,6 +136,22 @@ public class TestUtils {
 		return consumerConfig;
 	}
 
+	public static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {
+		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
+
+		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(fakeTotalCountOfSubtasks);
+		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(fakeIndexOfThisSubtask);
+		Mockito.when(mockedRuntimeContext.getTaskName()).thenReturn("Fake Task");
+		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(
+				"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
+		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
+				Thread.currentThread().getContextClassLoader());
+
+		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
+
+		return mockedRuntimeContext;
+	}
+
 	/**
 	 * A test record consumer used to capture messages from kinesis.
 	 */
@@ -154,4 +175,5 @@ public class TestUtils {
 			return recordBatches;
 		}
 	}
+
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestableKinesisDataFetcher.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestableKinesisDataFetcher.java
@@ -19,12 +19,9 @@
 
 package software.amazon.kinesis.connectors.flink.testutils;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher;
 import software.amazon.kinesis.connectors.flink.model.KinesisStreamShardState;
@@ -99,7 +96,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 			fakeStreams,
 			sourceContext,
 			sourceContext.getCheckpointLock(),
-			getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
+			TestUtils.getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
 			fakeConfiguration,
 			deserializationSchema,
 			DEFAULT_SHARD_ASSIGNER,
@@ -168,19 +165,4 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 		initialDiscoveryWaiter.await();
 	}
 
-	private static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {
-		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
-
-		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(fakeTotalCountOfSubtasks);
-		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(fakeIndexOfThisSubtask);
-		Mockito.when(mockedRuntimeContext.getTaskName()).thenReturn("Fake Task");
-		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(
-				"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
-		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
-				Thread.currentThread().getContextClassLoader());
-
-		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
-
-		return mockedRuntimeContext;
-	}
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-connector-flink/issues/9

*Description of changes:*
Fix issue preventing DynamoDB stream consumers to start from `LATEST` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
