### PR TITLE
Improving error handling when source is interrupted during job failure/cancellation

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
@@ -736,6 +736,11 @@ public class KinesisDataFetcher<T> {
 	 * Once called, the shutdown procedure will be executed and all shard consuming threads will be interrupted.
 	 */
 	public void shutdownFetcher() {
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Starting shutdown of shard consumer threads and AWS SDK resources of subtask {} ...",
+					indexOfThisConsumerSubtask);
+		}
+
 		running = false;
 
 		StreamConsumerRegistrarUtil.deregisterStreamConsumers(configProps, streams);
@@ -756,6 +761,14 @@ public class KinesisDataFetcher<T> {
 		if (LOG.isInfoEnabled()) {
 			LOG.info("Shutting down the shard consumer threads of subtask {} ...", indexOfThisConsumerSubtask);
 		}
+	}
+
+	/**
+	 * Returns a flag indicating if this fetcher is running.
+	 * @return true if the fetch is running, false if it has been shutdown
+	 */
+	boolean isRunning() {
+		return running;
 	}
 
 	/**

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumer.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumer.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import static java.util.Optional.ofNullable;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.CANCELLED;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 
 /**
@@ -132,6 +133,10 @@ public class ShardConsumer<T> implements Runnable {
 					fetcherRef.updateState(subscribedShardStateIndex, SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
 					// we can close this consumer thread once we've reached the end of the subscribed shard
 					break;
+				} else if (result == CANCELLED) {
+					final String errorMessage = "Shard consumer cancelled: " + subscribedShard.getShard().getShardId();
+					LOG.info(errorMessage);
+					throw new ShardConsumerCancelledException(errorMessage);
 				}
 			}
 		} catch (Throwable t) {
@@ -141,12 +146,13 @@ public class ShardConsumer<T> implements Runnable {
 
 	/**
 	 * The loop in run() checks this before fetching next batch of records. Since this runnable will be executed
-	 * by the ExecutorService {@code KinesisDataFetcher#shardConsumersExecutor}, the only way to close down this thread
-	 * would be by calling shutdownNow() on {@code KinesisDataFetcher#shardConsumersExecutor} and let the executor service
-	 * interrupt all currently running {@link ShardConsumer}s.
+	 * by the ExecutorService {@code KinesisDataFetcher#shardConsumersExecutor}, this thread would be closed down
+	 * by calling shutdownNow() on {@code KinesisDataFetcher#shardConsumersExecutor} and let the executor service
+	 * interrupt all currently running {@link ShardConsumer}s. The AWS SDK resources must be shutdown prior to this
+	 * thread in order to preserve classpath for teardown, therefore also check to see if the fetcher is still running.
 	 */
 	private boolean isRunning() {
-		return !Thread.interrupted();
+		return !Thread.interrupted() && fetcherRef.isRunning();
 	}
 
 	/**
@@ -209,4 +215,27 @@ public class ShardConsumer<T> implements Runnable {
 		return !record.getSequenceNumber().equals(lastSequenceNum.getSequenceNumber()) ||
 			record.getSubSequenceNumber() > lastSequenceNum.getSubSequenceNumber();
 	}
+
+	/**
+	 * An exception wrapper to indicate an error has been thrown from the shard consumer.
+	 */
+	abstract static class ShardConsumerException extends RuntimeException {
+		private static final long serialVersionUID = 7732343624482321663L;
+
+		public ShardConsumerException(final String message) {
+			super(message);
+		}
+	}
+
+	/**
+	 * An exception to indicate the shard consumer has been cancelled.
+	 */
+	static class ShardConsumerCancelledException extends ShardConsumerException {
+		private static final long serialVersionUID = 2707399313569728649L;
+
+		public ShardConsumerCancelledException(final String message) {
+			super(message);
+		}
+	}
+
 }

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/RecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/RecordPublisher.java
@@ -47,7 +47,10 @@ public interface RecordPublisher {
 		COMPLETE,
 
 		/** There are more records to consume from this shard. */
-		INCOMPLETE
+		INCOMPLETE,
+
+		/** The record publisher has been cancelled. */
+		CANCELLED
 	}
 
 	/**

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
@@ -57,6 +57,7 @@ import software.amazon.kinesis.connectors.flink.testutils.TestableKinesisDataFet
 import software.amazon.kinesis.connectors.flink.testutils.TestableKinesisDataFetcherForShardConsumerException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -70,6 +71,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -90,27 +92,25 @@ import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigCons
  */
 public class KinesisDataFetcherTest extends TestLogger {
 
+	@Test
+	public void testIsRunning() {
+		KinesisDataFetcher<String> fetcher = createTestDataFetcherWithNoShards(10, 2, "test-stream");
+
+		assertTrue(fetcher.isRunning());
+	}
+
+	@Test
+	public void testIsRunningFalseAfterShutDown() {
+		KinesisDataFetcher<String> fetcher = createTestDataFetcherWithNoShards(10, 2, "test-stream");
+
+		fetcher.shutdownFetcher();
+
+		assertFalse(fetcher.isRunning());
+	}
+
 	@Test(expected = RuntimeException.class)
 	public void testIfNoShardsAreFoundShouldThrowException() throws Exception {
-		List<String> fakeStreams = new LinkedList<>();
-		fakeStreams.add("fakeStream1");
-		fakeStreams.add("fakeStream2");
-
-		HashMap<String, String> subscribedStreamsToLastSeenShardIdsUnderTest =
-			KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(fakeStreams);
-
-		TestableKinesisDataFetcher<String> fetcher =
-			new TestableKinesisDataFetcher<>(
-				fakeStreams,
-				new TestSourceContext<>(),
-				TestUtils.getStandardProperties(),
-				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
-				10,
-				2,
-				new AtomicReference<>(),
-				new LinkedList<>(),
-				subscribedStreamsToLastSeenShardIdsUnderTest,
-				FakeKinesisBehavioursFactory.noShardsFoundForRequestedStreamsBehaviour());
+		KinesisDataFetcher<String> fetcher = createTestDataFetcherWithNoShards(10, 2, "fakeStream1", "fakeStream2");
 
 		fetcher.runFetcher(); // this should throw RuntimeException
 	}
@@ -802,7 +802,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 		Assert.assertEquals(record1, sourceContext.getCollectedOutputs().poll());
 
 		fetcher.emitWatermark();
-		Assert.assertTrue("potential watermark equals previous watermark", watermarks.isEmpty());
+		assertTrue("potential watermark equals previous watermark", watermarks.isEmpty());
 
 		StreamRecord<String> record2 = new StreamRecord<>(String.valueOf(1), 1);
 		fetcher.emitRecordAndUpdateState(record2.getValue(), record2.getTimestamp(), shardIndex, seq);
@@ -819,13 +819,13 @@ public class KinesisDataFetcherTest extends TestLogger {
 		clock.add(idleTimeout + 1);
 		fetcher.emitWatermark();
 		Assert.assertFalse("not idle", isTemporaryIdle.booleanValue());
-		Assert.assertTrue("not idle, no new watermark", watermarks.isEmpty());
+		assertTrue("not idle, no new watermark", watermarks.isEmpty());
 
 		// activate idle timeout
 		Whitebox.setInternalState(fetcher, "shardIdleIntervalMillis", idleTimeout);
 		fetcher.emitWatermark();
-		Assert.assertTrue("idle", isTemporaryIdle.booleanValue());
-		Assert.assertTrue("idle, no watermark", watermarks.isEmpty());
+		assertTrue("idle", isTemporaryIdle.booleanValue());
+		assertTrue("idle, no watermark", watermarks.isEmpty());
 	}
 
 	@Test
@@ -919,6 +919,26 @@ public class KinesisDataFetcherTest extends TestLogger {
 		fetcher.shutdownFetcher();
 
 		verify(kinesisV2).close();
+	}
+
+	private KinesisDataFetcher<String> createTestDataFetcherWithNoShards(
+			final int subtaskCount, final int subtaskIndex, final String...streams) {
+		List<String> streamList = Arrays.stream(streams).collect(Collectors.toList());
+
+		HashMap<String, String> subscribedStreamsToLastSeenShardIdsUnderTest =
+				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(streamList);
+
+		return new TestableKinesisDataFetcher<String>(
+				streamList,
+				new TestSourceContext<>(),
+				TestUtils.getStandardProperties(),
+				new KinesisDeserializationSchemaWrapper<String>(new SimpleStringSchema()),
+				subtaskCount,
+				subtaskIndex,
+				new AtomicReference<>(),
+				new LinkedList<>(),
+				subscribedStreamsToLastSeenShardIdsUnderTest,
+				FakeKinesisBehavioursFactory.noShardsFoundForRequestedStreamsBehaviour());
 	}
 
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerFanOutTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerFanOutTest.java
@@ -19,6 +19,8 @@
 
 package software.amazon.kinesis.connectors.flink.internals;
 
+import com.amazonaws.SdkClientException;
+import com.amazonaws.http.timers.client.SdkInterruptedException;
 import org.junit.Test;
 import software.amazon.awssdk.services.kinesis.model.StartingPosition;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutRecordPublisherFactory;
@@ -40,6 +42,7 @@ import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.AT
 import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.STREAM_TIMESTAMP_DATE_FORMAT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_MAX;
 import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.fakeSequenceNumber;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
@@ -208,6 +211,45 @@ public class ShardConsumerFanOutTest {
 		assertStartingPositionAfterSequenceNumber(kinesis.getStartingPositionForSubscription(2), "4");
 		assertStartingPositionAfterSequenceNumber(kinesis.getStartingPositionForSubscription(3), "6");
 		assertStartingPositionAfterSequenceNumber(kinesis.getStartingPositionForSubscription(4), "8");
+	}
+
+	@Test
+	public void testShardConsumerExitsWhenRecordPublisherIsInterrupted() throws Exception {
+		// Throws error after 5 records
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(new SdkInterruptedException(null));
+
+		int expectedNumberOfRecordsReadFromKinesisBeforeError = 5;
+		SequenceNumber startingSequenceNumber = new SequenceNumber("0");
+		SequenceNumber expectedLastProcessSequenceNumber = new SequenceNumber("5");
+
+		// SdkInterruptedException will terminate the consumer, it will not retry and read only the first 5 records
+		ShardConsumerTestUtils.assertNumberOfMessagesReceivedFromKinesis(
+				expectedNumberOfRecordsReadFromKinesisBeforeError,
+				new FanOutRecordPublisherFactory(kinesis),
+				startingSequenceNumber,
+				efoProperties(),
+				expectedLastProcessSequenceNumber);
+	}
+
+	@Test
+	public void testShardConsumerRetriesGenericSdkError() throws Exception {
+		// Throws error after 5 records and there are 25 records available in the shard
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(new SdkClientException(""));
+
+		int expectedNumberOfRecordsReadFromKinesisBeforeError = 25;
+		SequenceNumber startingSequenceNumber = new SequenceNumber("0");
+
+		Properties properties = efoProperties();
+		// Speed up test by reducing backoff time
+		properties.setProperty(SUBSCRIBE_TO_SHARD_BACKOFF_MAX, "1");
+
+		// SdkClientException will cause a retry, each retry will result in 5 more records being consumed
+		// The shard will consume all 25 records
+		assertNumberOfMessagesReceivedFromKinesis(
+				expectedNumberOfRecordsReadFromKinesisBeforeError,
+				kinesis,
+				startingSequenceNumber,
+				properties);
 	}
 
 	private void assertStartingPositionAfterSequenceNumber(

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTestUtils.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTestUtils.java
@@ -57,10 +57,24 @@ import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNum
 public class ShardConsumerTestUtils {
 
 	public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+			final int expectedNumberOfMessages,
+			final RecordPublisherFactory recordPublisherFactory,
+			final SequenceNumber startingSequenceNumber,
+			final Properties consumerProperties) throws InterruptedException {
+		return assertNumberOfMessagesReceivedFromKinesis(
+				expectedNumberOfMessages,
+				recordPublisherFactory,
+				startingSequenceNumber,
+				consumerProperties,
+				SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
+	}
+
+	public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
 				final int expectedNumberOfMessages,
 				final RecordPublisherFactory recordPublisherFactory,
 				final SequenceNumber startingSequenceNumber,
-				final Properties consumerProperties) throws InterruptedException {
+				final Properties consumerProperties,
+				final SequenceNumber expectedLastProcessedSequenceNum) throws InterruptedException {
 		ShardConsumerMetricsReporter shardMetricsReporter = new ShardConsumerMetricsReporter(mock(MetricGroup.class));
 
 		StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
@@ -107,9 +121,7 @@ public class ShardConsumerTestUtils {
 			.run();
 
 		assertEquals(expectedNumberOfMessages, sourceContext.getCollectedOutputs().size());
-		assertEquals(
-			SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
-			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
+		assertEquals(expectedLastProcessedSequenceNum, subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 
 		return shardMetricsReporter;
 	}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -19,6 +19,7 @@
 
 package software.amazon.kinesis.connectors.flink.internals.publisher.fanout;
 
+import com.amazonaws.http.timers.client.SdkInterruptedException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,6 +62,20 @@ public class FanOutShardSubscriberTest {
 
 		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
 			.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testInterruptedErrorThrownToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.FanOutSubscriberInterruptedException.class);
+
+		SdkInterruptedException error = new SdkInterruptedException(null);
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
+				.builder().build();
 		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
 	}
 


### PR DESCRIPTION
Improving error handling when source is interrupted during job failure/cancellation. Prior to this fix, in some cases the EFO consumer would treat interrupts as retryable exceptions, and increase time for job to exit.

*Description of changes:*
- Added a new exception `FanOutSubscriberInterruptedException` that is thrown by `FanOutShardSubscriber`
- Added a new result value that can be returned from `RecordPublisher`, `CANCELLED`. This causes shard consumer to exit
- `ShardConsumer` will exit when `RecordPublisher` is `CANCELLED`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
