### PR TITLE
[FLINK-21661][kinesis] Fix fetch interval for polling consumer

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/AdaptivePollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/AdaptivePollingRecordPublisher.java
@@ -29,9 +29,9 @@ import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
 import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyInterface;
 
 /**
- * An adaptive record publisher to add a dynamic loop delay and batch read size for {@link PollingRecordPublisher}.
- * Kinesis Streams have quotas on the transactions per second, and throughout. This class attempts to balance
- * quotas and mitigate back off errors.
+ * An adaptive record publisher to add a dynamic batch read size for {@link PollingRecordPublisher}.
+ * Kinesis Streams have quotas on the transactions per second, and throughout. This class attempts
+ * to balance quotas and mitigate back off errors.
  */
 @Internal
 public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
@@ -47,8 +47,6 @@ public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
 
 	private int maxNumberOfRecordsPerFetch;
 
-	private final long fetchIntervalMillis;
-
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
 	AdaptivePollingRecordPublisher(
@@ -60,7 +58,6 @@ public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
 			final long fetchIntervalMillis) throws InterruptedException {
 		super(startingPosition, subscribedShard, metricsReporter, kinesisProxy, maxNumberOfRecordsPerFetch, fetchIntervalMillis);
 		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
-		this.fetchIntervalMillis = fetchIntervalMillis;
 		this.metricsReporter = metricsReporter;
 	}
 
@@ -73,35 +70,12 @@ public class AdaptivePollingRecordPublisher extends PollingRecordPublisher {
 			return latestSequenceNumber;
 		}, maxNumberOfRecordsPerFetch);
 
-		long adjustmentEndTimeNanos = adjustRunLoopFrequency(processingStartTimeNanos, System.nanoTime());
-		long runLoopTimeNanos = adjustmentEndTimeNanos - processingStartTimeNanos;
+		long endTimeNanos = System.nanoTime();
+		long runLoopTimeNanos = endTimeNanos - processingStartTimeNanos;
 		maxNumberOfRecordsPerFetch = adaptRecordsToRead(runLoopTimeNanos, lastRecordBatchSize, lastRecordBatchSizeInBytes, maxNumberOfRecordsPerFetch);
-		processingStartTimeNanos = adjustmentEndTimeNanos;
-		metricsReporter.setRunLoopTimeNanos(runLoopTimeNanos);
+		processingStartTimeNanos = endTimeNanos;
 
 		return result;
-	}
-
-	/**
-	 * Adjusts loop timing to match target frequency if specified.
-	 * @param processingStartTimeNanos The start time of the run loop "work"
-	 * @param processingEndTimeNanos The end time of the run loop "work"
-	 * @return The System.nanoTime() after the sleep (if any)
-	 * @throws InterruptedException
-	 */
-	private long adjustRunLoopFrequency(long processingStartTimeNanos, long processingEndTimeNanos)
-			throws InterruptedException {
-		long endTimeNanos = processingEndTimeNanos;
-		if (fetchIntervalMillis != 0) {
-			long processingTimeNanos = processingEndTimeNanos - processingStartTimeNanos;
-			long sleepTimeMillis = fetchIntervalMillis - (processingTimeNanos / 1_000_000);
-			if (sleepTimeMillis > 0) {
-				Thread.sleep(sleepTimeMillis);
-				endTimeNanos = System.nanoTime();
-				metricsReporter.setSleepTimeMillis(sleepTimeMillis);
-			}
-		}
-		return endTimeNanos;
 	}
 
 	/**

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisher.java
@@ -62,7 +62,9 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 	private final int maxNumberOfRecordsPerFetch;
 
-	private final long expiredIteratorBackoffMillis;
+	private final long fetchIntervalMillis;
+
+	private long processingStartTimeNanos = System.nanoTime();
 
 	/**
 	 * A Polling implementation of {@link RecordPublisher} that polls kinesis for records.
@@ -73,7 +75,7 @@ public class PollingRecordPublisher implements RecordPublisher {
 	 * @param metricsReporter a metric reporter used to output metrics
 	 * @param kinesisProxy the proxy used to communicate with kinesis
 	 * @param maxNumberOfRecordsPerFetch the maximum number of records to retrieve per batch
-	 * @param expiredIteratorBackoffMillis the duration to sleep in the event of an {@link ExpiredIteratorException}
+	 * @param fetchIntervalMillis the target interval between each GetRecords invocation
 	 */
 	PollingRecordPublisher(
 			final StartingPosition startingPosition,
@@ -81,15 +83,15 @@ public class PollingRecordPublisher implements RecordPublisher {
 			final PollingRecordPublisherMetricsReporter metricsReporter,
 			final KinesisProxyInterface kinesisProxy,
 			final int maxNumberOfRecordsPerFetch,
-			final long expiredIteratorBackoffMillis) throws InterruptedException {
+			final long fetchIntervalMillis) throws InterruptedException {
 		this.nextStartingPosition = Preconditions.checkNotNull(startingPosition);
 		this.subscribedShard = Preconditions.checkNotNull(subscribedShard);
 		this.metricsReporter = Preconditions.checkNotNull(metricsReporter);
 		this.kinesisProxy = Preconditions.checkNotNull(kinesisProxy);
 		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
-		this.expiredIteratorBackoffMillis = expiredIteratorBackoffMillis;
+		this.fetchIntervalMillis = fetchIntervalMillis;
 
-		Preconditions.checkArgument(expiredIteratorBackoffMillis >= 0);
+		Preconditions.checkArgument(fetchIntervalMillis >= 0);
 		Preconditions.checkArgument(maxNumberOfRecordsPerFetch > 0);
 
 		this.nextShardItr = getShardIterator();
@@ -114,6 +116,14 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 		nextStartingPosition = getNextStartingPosition(latestSequenceNumber);
 		nextShardItr = result.getNextShardIterator();
+
+		long adjustmentEndTimeNanos =
+				adjustRunLoopFrequency(processingStartTimeNanos, System.nanoTime());
+		long runLoopTimeNanos = adjustmentEndTimeNanos - processingStartTimeNanos;
+
+		processingStartTimeNanos = adjustmentEndTimeNanos;
+		metricsReporter.setRunLoopTimeNanos(runLoopTimeNanos);
+
 		return nextShardItr == null ? COMPLETE : INCOMPLETE;
 	}
 
@@ -157,8 +167,8 @@ public class PollingRecordPublisher implements RecordPublisher {
 				shardItr = getShardIterator();
 
 				// sleep for the fetch interval before the next getRecords attempt with the refreshed iterator
-				if (expiredIteratorBackoffMillis != 0) {
-					Thread.sleep(expiredIteratorBackoffMillis);
+				if (fetchIntervalMillis != 0) {
+					Thread.sleep(fetchIntervalMillis);
 				}
 			}
 		}
@@ -176,5 +186,28 @@ public class PollingRecordPublisher implements RecordPublisher {
 			subscribedShard,
 			nextStartingPosition.getShardIteratorType().toString(),
 			nextStartingPosition.getStartingMarker());
+	}
+
+	/**
+	 * Adjusts loop timing to match target frequency if specified.
+	 *
+	 * @param processingStartTimeNanos The start time of the run loop "work"
+	 * @param processingEndTimeNanos The end time of the run loop "work"
+	 * @return The System.nanoTime() after the sleep (if any)
+	 * @throws InterruptedException
+	 */
+	private long adjustRunLoopFrequency(long processingStartTimeNanos, long processingEndTimeNanos)
+			throws InterruptedException {
+		long endTimeNanos = processingEndTimeNanos;
+		if (fetchIntervalMillis != 0) {
+			long processingTimeNanos = processingEndTimeNanos - processingStartTimeNanos;
+			long sleepTimeMillis = fetchIntervalMillis - (processingTimeNanos / 1_000_000);
+			if (sleepTimeMillis > 0) {
+				Thread.sleep(sleepTimeMillis);
+				endTimeNanos = System.nanoTime();
+				metricsReporter.setSleepTimeMillis(sleepTimeMillis);
+			}
+		}
+		return endTimeNanos;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Kinesis Polling consumer does not respect the `SHARD_GETRECORDS_INTERVAL_MILLIS` configuration. This means consumer will poll Kinesis without any delay, resulting in throttle. This bug was introduced with FLINK-18512.

## Brief change log

* Move sleep logic from `AdaptivePollingRecordPublisher` to `PollingRecordPublisher`, to respect `SHARD_GETRECORDS_INTERVAL_MILLIS`

## Verifying this change

This change added tests and can be verified as follows:
- `PollingRecordPublisherTest::testRunEmitsRunLoopTimeNanos`

This change is already covered by existing tests, such as:
- `ShardConsumerTest`
- `PollingRecordPublisherTest`
- Kinesis e2e Test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
