### PR TITLE
[EFO] Add timeout when waiting for subscription and delivering data to prevent lockup

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
@@ -178,6 +178,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
 	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
 
+	/** A timeout when waiting for a shard subscription to be established. */
+	public static final String SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS = "flink.shard.subscribetoshard.timeout";
+
 	/** The base backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
 
@@ -290,6 +293,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final double DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES = 10;
+
+	public static final Duration DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT = Duration.ofSeconds(60);
 
 	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE = 1000L;
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -135,9 +135,10 @@ public class FanOutRecordPublisher implements RecordPublisher {
 	private RecordPublisherRunResult runWithBackoff(
 			final Consumer<SubscribeToShardEvent> eventConsumer) throws InterruptedException {
 		FanOutShardSubscriber fanOutShardSubscriber = new FanOutShardSubscriber(
-			consumerArn,
-			subscribedShard.getShard().getShardId(),
-			kinesisProxy);
+				consumerArn,
+				subscribedShard.getShard().getShardId(),
+				kinesisProxy,
+				configuration.getSubscribeToShardTimeout());
 		boolean complete;
 
 		try {

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
@@ -65,6 +65,11 @@ public class FanOutRecordPublisherConfiguration {
 	private final int subscribeToShardMaxRetries;
 
 	/**
+	 * A timeout when waiting for a shard subscription to be established.
+	 */
+	private final Duration subscribeToShardTimeout;
+
+	/**
 	 * Maximum backoff millis for the subscribe to shard operation.
 	 */
 	private final long subscribeToShardMaxBackoffMillis;
@@ -196,6 +201,11 @@ public class FanOutRecordPublisherConfiguration {
 			.ofNullable(configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES))
 			.map(Integer::parseInt)
 			.orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES);
+		this.subscribeToShardTimeout = Optional
+				.ofNullable(configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS))
+				.map(Integer::parseInt)
+				.map(Duration::ofSeconds)
+				.orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 		this.subscribeToShardBaseBackoffMillis = Optional.ofNullable(
 			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE))
 			.map(Long::parseLong).orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE);
@@ -287,6 +297,13 @@ public class FanOutRecordPublisherConfiguration {
 	 */
 	public int getSubscribeToShardMaxRetries() {
 		return subscribeToShardMaxRetries;
+	}
+
+	/**
+	 * Get timeout when waiting for a shard subscription to be established.
+	 */
+	public Duration getSubscribeToShardTimeout() {
+		return subscribeToShardTimeout;
 	}
 
 	/**

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -25,8 +25,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import software.amazon.awssdk.services.kinesis.model.StartingPosition;
+import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyV2Interface;
 import software.amazon.kinesis.connectors.flink.testutils.FakeKinesisFanOutBehavioursFactory;
 import software.amazon.kinesis.connectors.flink.testutils.FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2;
+
+import java.time.Duration;
+
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT;
 
 /**
  * Tests for {@link FanOutShardSubscriber}.
@@ -43,7 +48,7 @@ public class FanOutShardSubscriberTest {
 
 		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(ReadTimeoutException.INSTANCE);
 
-		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2, DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
 		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
 			.builder().build();
@@ -58,7 +63,7 @@ public class FanOutShardSubscriberTest {
 		RuntimeException error = new RuntimeException("Error!");
 		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
 
-		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2, DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
 		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
 			.builder().build();
@@ -72,7 +77,7 @@ public class FanOutShardSubscriberTest {
 		SdkInterruptedException error = new SdkInterruptedException(null);
 		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
 
-		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2, DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
 		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
 				.builder().build();
@@ -88,10 +93,49 @@ public class FanOutShardSubscriberTest {
 		RuntimeException error2 = new RuntimeException("Error 2!");
 		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error1, error2);
 
-		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2, DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 
 		StartingPosition startingPosition = StartingPosition.builder().build();
 		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testTimeoutSubscribingToShard() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expectMessage("Timed out acquiring subscription");
+
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.failsToAcquireSubscription();
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", kinesis, Duration.ofMillis(1));
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testTimeoutEnqueuingEvent() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
+
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.boundedShard()
+				.withBatchCount(5)
+				.build();
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber(
+				"consumerArn",
+				"shardId",
+				kinesis,
+				DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT,
+				Duration.ofMillis(100));
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> {
+			try {
+				Thread.sleep(120);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		});
 	}
 
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -95,6 +95,10 @@ public class FakeKinesisFanOutBehavioursFactory {
 		return new AlternatingSubscriptionErrorKinesisV2(LimitExceededException.builder().build());
 	}
 
+	public static KinesisProxyV2Interface failsToAcquireSubscription() {
+		return new FailsToAcquireSubscriptionKinesis();
+	}
+
 	// ------------------------------------------------------------------------
 	//  Behaviours related to describing streams
 	// ------------------------------------------------------------------------
@@ -341,6 +345,20 @@ public class FakeKinesisFanOutBehavioursFactory {
 			public SingleShardFanOutKinesisV2 build() {
 				return new SingleShardFanOutKinesisV2(this);
 			}
+		}
+	}
+
+	/**
+	 * A dummy EFO implementation that fails to acquire subscription (no response).
+	 */
+	private static class FailsToAcquireSubscriptionKinesis extends KinesisProxyV2InterfaceAdapter {
+
+		@Override
+		public CompletableFuture<Void> subscribeToShard(
+				final SubscribeToShardRequest request,
+				final SubscribeToShardResponseHandler responseHandler) {
+
+			return CompletableFuture.supplyAsync(() -> null);
 		}
 	}
 


### PR DESCRIPTION
*Description of changes:*
Add timeout when:
- Waiting to acquire subscription
- Delivering data/completion events from network thread to source thread

If timeout fires the EFO source will cancel subscription, backoff and retry. This change is intended to prevent deadlocks from occurring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
