### PR TITLE
Treating TimeoutException as Recoverable

### DIFF
--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -101,7 +101,7 @@ public class FanOutShardSubscriberTest {
 
 	@Test
 	public void testTimeoutSubscribingToShard() throws Exception {
-		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out acquiring subscription");
 
 		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.failsToAcquireSubscription();
@@ -114,7 +114,7 @@ public class FanOutShardSubscriberTest {
 
 	@Test
 	public void testTimeoutEnqueuingEvent() throws Exception {
-		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
 
 		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.boundedShard()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-connector-flink/issues/21

*Description of changes:*
Handle `TimeoutException` using the same mechanism as Netty `ReadTimeoutException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
