### PR TITLE
[EFO][backport] Add timeout when waiting for subscription and delivering data to prevent lockup

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
@@ -26,6 +26,8 @@ import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
 import software.amazon.kinesis.connectors.flink.internals.ShardConsumer;
 import software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber;
 
+import java.time.Duration;
+
 /**
  * Optional consumer specific configuration keys and default values for {@link FlinkKinesisConsumer}.
  */
@@ -176,6 +178,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The maximum number of subscribeToShard attempts if we get a recoverable exception. */
 	public static final String SUBSCRIBE_TO_SHARD_RETRIES = "flink.shard.subscribetoshard.maxretries";
 
+	/** A timeout when waiting for a shard subscription to be established. */
+	public static final String SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS = "flink.shard.subscribetoshard.timeout";
+
 	/** The base backoff time between each subscribeToShard attempt. */
 	public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE = "flink.shard.subscribetoshard.backoff.base";
 
@@ -288,6 +293,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final double DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES = 10;
+
+	public static final Duration DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT = Duration.ofSeconds(60);
 
 	public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE = 1000L;
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -133,9 +133,10 @@ public class FanOutRecordPublisher implements RecordPublisher {
 	private RecordPublisherRunResult runWithBackoff(
 			final Consumer<SubscribeToShardEvent> eventConsumer) throws InterruptedException {
 		FanOutShardSubscriber fanOutShardSubscriber = new FanOutShardSubscriber(
-			consumerArn,
-			subscribedShard.getShard().getShardId(),
-			kinesisProxy);
+				consumerArn,
+				subscribedShard.getShard().getShardId(),
+				kinesisProxy,
+				configuration.getSubscribeToShardTimeout());
 		boolean complete;
 
 		try {

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
@@ -61,6 +61,11 @@ public class FanOutRecordPublisherConfiguration {
 	private final int subscribeToShardMaxRetries;
 
 	/**
+	 * A timeout when waiting for a shard subscription to be established.
+	 */
+	private final Duration subscribeToShardTimeout;
+
+	/**
 	 * Maximum backoff millis for the subscribe to shard operation.
 	 */
 	private final long subscribeToShardMaxBackoffMillis;
@@ -192,6 +197,11 @@ public class FanOutRecordPublisherConfiguration {
 			configProps.getProperty(
 				ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES)));
+		this.subscribeToShardTimeout = Optional
+				.ofNullable(configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS))
+				.map(Integer::parseInt)
+				.map(Duration::ofSeconds)
+				.orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
 		this.subscribeToShardBaseBackoffMillis = Long.parseLong(
 			configProps.getProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_BACKOFF_BASE,
 				Long.toString(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE)));
@@ -280,6 +290,13 @@ public class FanOutRecordPublisherConfiguration {
 	 */
 	public int getSubscribeToShardMaxRetries() {
 		return subscribeToShardMaxRetries;
+	}
+
+	/**
+	 * Get timeout when waiting for a shard subscription to be established.
+	 */
+	public Duration getSubscribeToShardTimeout() {
+		return subscribeToShardTimeout;
 	}
 
 	/**

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -20,6 +20,7 @@
 package software.amazon.kinesis.connectors.flink.internals.publisher.fanout;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
 import io.netty.handler.timeout.ReadTimeoutException;
@@ -37,15 +38,18 @@ import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHan
 import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyV2;
 import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyV2Interface;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * This class is responsible for acquiring an Enhanced Fan Out subscription and consuming records from a shard.
@@ -88,12 +92,9 @@ public class FanOutShardSubscriber {
 	private static final int QUEUE_CAPACITY = 1;
 
 	/**
-	 * Read timeout will occur after 30 seconds, a sanity timeout to prevent lockup in unexpected error states.
-	 * If the consumer does not receive a new event within the DEQUEUE_WAIT_SECONDS it will backoff and resubscribe.
-	 * Under normal conditions heartbeat events are received even when there are no records to consume, so it is not
-	 * expected for this timeout to occur under normal conditions.
+	 * If the consumer does not receive a new event within the DEFAULT_QUEUE_TIMEOUT it will backoff and resubscribe.
 	 */
-	private static final int DEQUEUE_WAIT_SECONDS = 35;
+	private static final Duration DEFAULT_QUEUE_TIMEOUT = Duration.ofSeconds(35);
 
 	private final BlockingQueue<FanOutSubscriptionEvent> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
 
@@ -105,17 +106,48 @@ public class FanOutShardSubscriber {
 
 	private final String shardId;
 
+	private final Duration subscribeToShardTimeout;
+
+	private final Duration queueWaitTimeout;
+
+	/**
+	 * Create a new Fan Out Shard Subscriber.
+	 *
+	 * @param consumerArn the stream consumer ARN
+	 * @param shardId the shard ID to subscribe to
+	 * @param kinesis the Kinesis Proxy used to communicate via AWS SDK v2
+	 * @param subscribeToShardTimeout A timeout when waiting for a shard subscription to be established
+	 */
+	FanOutShardSubscriber(
+			final String consumerArn,
+			final String shardId,
+			final KinesisProxyV2Interface kinesis,
+			final Duration subscribeToShardTimeout) {
+		this(consumerArn, shardId, kinesis, subscribeToShardTimeout, DEFAULT_QUEUE_TIMEOUT);
+
+	}
+
 	/**
 	 * Create a new Fan Out subscriber.
 	 *
 	 * @param consumerArn the stream consumer ARN
 	 * @param shardId the shard ID to subscribe to
 	 * @param kinesis the Kinesis Proxy used to communicate via AWS SDK v2
+	 * @param subscribeToShardTimeout A timeout when waiting for a shard subscription to be established
+	 * @param queueWaitTimeout A timeout when enqueuing/de-queueing
 	 */
-	FanOutShardSubscriber(final String consumerArn, final String shardId, final KinesisProxyV2Interface kinesis) {
+	@VisibleForTesting
+	FanOutShardSubscriber(
+			final String consumerArn,
+			final String shardId,
+			final KinesisProxyV2Interface kinesis,
+			final Duration subscribeToShardTimeout,
+			final Duration queueWaitTimeout) {
 		this.kinesis = Preconditions.checkNotNull(kinesis);
 		this.consumerArn = Preconditions.checkNotNull(consumerArn);
 		this.shardId = Preconditions.checkNotNull(shardId);
+		this.subscribeToShardTimeout = subscribeToShardTimeout;
+		this.queueWaitTimeout = queueWaitTimeout;
 	}
 
 	/**
@@ -134,8 +166,9 @@ public class FanOutShardSubscriber {
 			final Consumer<SubscribeToShardEvent> eventConsumer) throws InterruptedException, FanOutSubscriberException {
 		LOG.debug("Subscribing to shard {} ({})", shardId, consumerArn);
 
+		final FanOutShardSubscription subscription;
 		try {
-			openSubscriptionToShard(startingPosition);
+			subscription = openSubscriptionToShard(startingPosition);
 		} catch (FanOutSubscriberException ex) {
 			// The only exception that should cause a failure is a ResourceNotFoundException
 			// Rethrow the exception to trigger the application to terminate
@@ -146,7 +179,7 @@ public class FanOutShardSubscriber {
 			throw ex;
 		}
 
-		return consumeAllRecordsFromKinesisShard(eventConsumer);
+		return consumeAllRecordsFromKinesisShard(eventConsumer, subscription);
 	}
 
 	/**
@@ -157,7 +190,7 @@ public class FanOutShardSubscriber {
 	 * @param startingPosition the position in which to start consuming from
 	 * @throws FanOutSubscriberException when an exception is propagated from the networking stack
 	 */
-	private void openSubscriptionToShard(final StartingPosition startingPosition) throws FanOutSubscriberException, InterruptedException {
+	private FanOutShardSubscription openSubscriptionToShard(final StartingPosition startingPosition) throws FanOutSubscriberException, InterruptedException {
 		SubscribeToShardRequest request = SubscribeToShardRequest.builder()
 			.consumerARN(consumerArn)
 			.shardId(shardId)
@@ -184,7 +217,15 @@ public class FanOutShardSubscriber {
 
 		kinesis.subscribeToShard(request, responseHandler);
 
-		waitForSubscriptionLatch.await();
+		boolean subscriptionEstablished = waitForSubscriptionLatch
+				.await(subscribeToShardTimeout.toMillis(), TimeUnit.MILLISECONDS);
+
+		if (!subscriptionEstablished) {
+			final String errorMessage = "Timed out acquiring subscription - " + shardId + " (" + consumerArn + ")";
+			LOG.error(errorMessage);
+			subscription.cancelSubscription();
+			throw new RetryableFanOutSubscriberException(new TimeoutException(errorMessage));
+		}
 
 		Throwable throwable = exception.get();
 		if (throwable != null) {
@@ -196,6 +237,8 @@ public class FanOutShardSubscriber {
 		// Request the first record to kick off consumption
 		// Following requests are made by the FanOutShardSubscription on the netty thread
 		subscription.requestRecord();
+
+		return subscription;
 	}
 
 	/**
@@ -256,21 +299,24 @@ public class FanOutShardSubscriber {
 	 * @throws InterruptedException when the thread is interrupted
 	 */
 	private boolean consumeAllRecordsFromKinesisShard(
-			final Consumer<SubscribeToShardEvent> eventConsumer) throws InterruptedException, FanOutSubscriberException {
+			final Consumer<SubscribeToShardEvent> eventConsumer,
+			final FanOutShardSubscription subscription) throws InterruptedException, FanOutSubscriberException {
 		String continuationSequenceNumber;
+		boolean result = true;
 
 		do {
 			FanOutSubscriptionEvent subscriptionEvent;
-			if (queue.isEmpty() && subscriptionErrorEvent.get() != null) {
+			if (subscriptionErrorEvent.get() != null) {
 				subscriptionEvent = subscriptionErrorEvent.get();
 			} else {
 				// Read timeout will occur after 30 seconds, add a sanity timeout here to prevent lockup
-				subscriptionEvent = queue.poll(DEQUEUE_WAIT_SECONDS, SECONDS);
+				subscriptionEvent = queue.poll(queueWaitTimeout.toMillis(), MILLISECONDS);
 			}
 
 			if (subscriptionEvent == null) {
-				LOG.info("Timed out polling events from network, reacquiring subscription - {} ({})", shardId, consumerArn);
-				return false;
+				LOG.debug("Timed out polling events from network, reacquiring subscription - {} ({})", shardId, consumerArn);
+				result = false;
+				break;
 			} else if (subscriptionEvent.isSubscribeToShardEvent()) {
 				SubscribeToShardEvent event = subscriptionEvent.getSubscribeToShardEvent();
 				continuationSequenceNumber = event.continuationSequenceNumber();
@@ -278,19 +324,18 @@ public class FanOutShardSubscriber {
 					eventConsumer.accept(event);
 				}
 			} else if (subscriptionEvent.isSubscriptionComplete()) {
-				if (subscriptionErrorEvent.get() != null) {
-					handleError(subscriptionErrorEvent.get().getThrowable());
-				}
-
 				// The subscription is complete, but the shard might not be, so we return incomplete
-				return false;
+				result = false;
+				break;
 			} else {
 				handleError(subscriptionEvent.getThrowable());
-				return false;
+				result = false;
+				break;
 			}
 		} while (continuationSequenceNumber != null);
 
-		return true;
+		subscription.cancelSubscription();
+		return result;
 	}
 
 	/**
@@ -342,13 +387,19 @@ public class FanOutShardSubscriber {
 			LOG.debug("Error occurred on EFO subscription: {} - ({}).  {} ({})",
 				throwable.getClass().getName(), throwable.getMessage(), shardId, consumerArn, throwable);
 
+			SubscriptionErrorEvent subscriptionErrorEvent = new SubscriptionErrorEvent(throwable);
+			if (FanOutShardSubscriber.this.subscriptionErrorEvent.get() == null) {
+				FanOutShardSubscriber.this.subscriptionErrorEvent.set(subscriptionErrorEvent);
+			} else {
+				LOG.warn("Error already queued. Ignoring subsequent exception.", throwable);
+			}
+
 			// Cancel the subscription to signal the onNext to stop requesting data
 			cancelSubscription();
 
-			if (subscriptionErrorEvent.get() == null) {
-				subscriptionErrorEvent.set(new SubscriptionErrorEvent(throwable));
-			} else {
-				LOG.warn("Previous error passed to consumer for processing. Ignoring subsequent exception.", throwable);
+			// If there is space in the queue, insert the error to wake up blocked thread
+			if (queue.isEmpty()) {
+				queue.offer(subscriptionErrorEvent);
 			}
 		}
 
@@ -359,20 +410,33 @@ public class FanOutShardSubscriber {
 		}
 
 		private void cancelSubscription() {
-			if (!cancelled) {
-				cancelled = true;
+			if (cancelled) {
+				return;
+			}
+			cancelled = true;
+
+			if (subscription != null) {
 				subscription.cancel();
 			}
 		}
 
 		/**
-		 * Adds the event to the queue blocking until complete.
+		 * Adds the event to the queue, times out after 35 seconds and raises error.
 		 *
 		 * @param event the event to enqueue
 		 */
 		private void enqueueEvent(final FanOutSubscriptionEvent event) {
+			if (cancelled) {
+				return;
+			}
+
 			try {
-				queue.put(event);
+				if (!queue.offer(event, queueWaitTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+					final String errorMessage = "Timed out enqueuing event " + event.getClass().getSimpleName() + " - "
+							+ shardId + " (" + consumerArn + ")";
+					LOG.error(errorMessage);
+					onError(new TimeoutException(errorMessage));
+				}
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				throw new RuntimeException(e);

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
@@ -24,9 +24,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.testutils.TestUtils;
 
@@ -41,23 +38,26 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS;
 
 /**
  * Tests for {@link FanOutRecordPublisherConfiguration}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FanOutRecordPublisherConfiguration.class)
 public class FanOutRecordPublisherConfigurationTest extends TestLogger {
+
 	@Rule
-	private ExpectedException exception = ExpectedException.none();
+	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testPollingRecordPublisher() {
-		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage("Only efo record publisher can register a FanOutProperties.");
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("Only efo record publisher can register a FanOutProperties.");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.POLLING.toString());
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.POLLING.toString());
 
 		new FanOutRecordPublisherConfiguration(testConfig, new ArrayList<>());
 	}
@@ -66,21 +66,21 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 	public void testEagerStrategyWithConsumerName() {
 		String fakedConsumerName = "fakedconsumername";
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
-		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, fakedConsumerName);
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+		testConfig.setProperty(EFO_CONSUMER_NAME, fakedConsumerName);
 		FanOutRecordPublisherConfiguration fanOutRecordPublisherConfiguration = new FanOutRecordPublisherConfiguration(testConfig, new ArrayList<>());
 		assertEquals(fanOutRecordPublisherConfiguration.getConsumerName(), Optional.of(fakedConsumerName));
 	}
 
 	@Test
 	public void testEagerStrategyWithNoConsumerName() {
-		String msg = "No valid enhanced fan-out consumer name is set through " + ConsumerConfigConstants.EFO_CONSUMER_NAME;
+		String msg = "No valid enhanced fan-out consumer name is set through " + EFO_CONSUMER_NAME;
 
-		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(msg);
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(msg);
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
 		new FanOutRecordPublisherConfiguration(testConfig, new ArrayList<>());
 	}
 
@@ -88,7 +88,7 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 	public void testNoneStrategyWithStreams() {
 		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, ConsumerConfigConstants.EFORegistrationType.NONE.toString());
 		streams.forEach(
 			stream ->
@@ -107,11 +107,11 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
 
 		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream1, flink.stream.efo.consumerarn.fakedstream2";
-		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(msg);
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(msg);
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, ConsumerConfigConstants.EFORegistrationType.NONE.toString());
 
 		new FanOutRecordPublisherConfiguration(testConfig, streams);
@@ -122,11 +122,11 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 		List<String> streams = Arrays.asList("fakedstream1", "fakedstream2");
 
 		String msg = "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream2";
-		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage(msg);
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(msg);
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_REGISTRATION_TYPE, ConsumerConfigConstants.EFORegistrationType.NONE.toString());
 		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX + "." + "fakedstream1", "fakedstream1");
 
@@ -136,8 +136,8 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 	@Test
 	public void testParseRegisterStreamConsumerTimeout() {
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
-		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "name");
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+		testConfig.setProperty(EFO_CONSUMER_NAME, "name");
 		testConfig.setProperty(ConsumerConfigConstants.REGISTER_STREAM_TIMEOUT_SECONDS, "120");
 
 		FanOutRecordPublisherConfiguration configuration = new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
@@ -149,14 +149,37 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 	@Test
 	public void testParseDeregisterStreamConsumerTimeout() {
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.toString());
-		testConfig.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "name");
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+		testConfig.setProperty(EFO_CONSUMER_NAME, "name");
 		testConfig.setProperty(ConsumerConfigConstants.DEREGISTER_STREAM_TIMEOUT_SECONDS, "240");
 
 		FanOutRecordPublisherConfiguration configuration = new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
 
 		assertEquals(Duration.ofSeconds(60), configuration.getRegisterStreamConsumerTimeout());
 		assertEquals(Duration.ofSeconds(240), configuration.getDeregisterStreamConsumerTimeout());
+	}
+
+	@Test
+	public void testParseSubscribeToShardTimeout() {
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+		testConfig.setProperty(EFO_CONSUMER_NAME, "name");
+		testConfig.setProperty(SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS, "123");
+
+		FanOutRecordPublisherConfiguration configuration = new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
+
+		assertEquals(Duration.ofSeconds(123), configuration.getSubscribeToShardTimeout());
+	}
+
+	@Test
+	public void testDefaultSubscribeToShardTimeout() {
+		Properties testConfig = TestUtils.getStandardProperties();
+		testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+		testConfig.setProperty(EFO_CONSUMER_NAME, "name");
+
+		FanOutRecordPublisherConfiguration configuration = new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
+
+		assertEquals(Duration.ofSeconds(60), configuration.getSubscribeToShardTimeout());
 	}
 
 }


### PR DESCRIPTION
*Description of changes:*

This is a backport of https://github.com/awslabs/amazon-kinesis-connector-flink/pull/18

Add timeout when:
- Waiting to acquire subscription
- Delivering data/completion events from network thread to source thread

If timeout fires the EFO source will cancel subscription, backoff and retry. This change is intended to prevent deadlocks from occurring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
