### PR TITLE
[source][backport] Backporting bug fixes and improvements from v2.0.3

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
@@ -673,31 +673,52 @@ public class KinesisDataFetcher<T> {
 	 * Once called, the shutdown procedure will be executed and all shard consuming threads will be interrupted.
 	 */
 	public void shutdownFetcher() {
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Starting shutdown of shard consumer threads and AWS SDK resources of subtask {} ...",
-					indexOfThisConsumerSubtask);
-		}
+		LOG.info("Starting shutdown of shard consumer threads and AWS SDK resources of subtask {} ...",
+				indexOfThisConsumerSubtask, error.get());
 
 		running = false;
+		try {
+			try {
+				deregisterStreamConsumer();
+			} catch (Exception e) {
+				LOG.warn("Encountered exception deregistering stream consumers", e);
+			}
 
-		StreamConsumerRegistrarUtil.deregisterStreamConsumers(configProps, streams);
+			try {
+				closeRecordPublisherFactory();
+			} catch (Exception e) {
+				LOG.warn("Encountered exception closing record publisher factory", e);
+			}
+		} finally {
+			shardConsumersExecutor.shutdownNow();
 
+			if (mainThread != null) {
+				mainThread.interrupt(); // the main thread may be sleeping for the discovery interval
+			}
+
+			if (watermarkTracker != null) {
+				watermarkTracker.close();
+			}
+			this.recordEmitter.stop();
+		}
+
+		LOG.info("Shutting down the shard consumer threads of subtask {} ...", indexOfThisConsumerSubtask);
+	}
+
+	/**
+	 * Closes recordRecordPublisherFactory. Allows test to override this to simulate exception for shutdown logic.
+	 */
+	@VisibleForTesting
+	protected void closeRecordPublisherFactory() {
 		recordPublisherFactory.close();
+	}
 
-		shardConsumersExecutor.shutdownNow();
-
-		if (mainThread != null) {
-			mainThread.interrupt(); // the main thread may be sleeping for the discovery interval
-		}
-
-		if (watermarkTracker != null) {
-			watermarkTracker.close();
-		}
-		this.recordEmitter.stop();
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Shutting down the shard consumer threads of subtask {} ...", indexOfThisConsumerSubtask);
-		}
+	/**
+	 * Deregisters stream consumers. Allows test to override this to simulate exception for shutdown logic.
+	 */
+	@VisibleForTesting
+	protected void deregisterStreamConsumer() {
+		StreamConsumerRegistrarUtil.deregisterStreamConsumers(configProps, streams);
 	}
 
 	/**

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -224,7 +224,7 @@ public class FanOutShardSubscriber {
 			final String errorMessage = "Timed out acquiring subscription - " + shardId + " (" + consumerArn + ")";
 			LOG.error(errorMessage);
 			subscription.cancelSubscription();
-			throw new RetryableFanOutSubscriberException(new TimeoutException(errorMessage));
+			handleError(new RecoverableFanOutSubscriberException(new TimeoutException(errorMessage)));
 		}
 
 		Throwable throwable = exception.get();
@@ -260,6 +260,8 @@ public class FanOutShardSubscriber {
 
 		if (isInterrupted(throwable)) {
 			throw new FanOutSubscriberInterruptedException(throwable);
+		} else if (cause instanceof FanOutSubscriberException) {
+			throw (FanOutSubscriberException) cause;
 		} else if (cause instanceof ReadTimeoutException) {
 			// ReadTimeoutException occurs naturally under backpressure scenarios when full batches take longer to
 			// process than standard read timeout (default 30s). Recoverable exceptions are intended to be retried
@@ -435,7 +437,7 @@ public class FanOutShardSubscriber {
 					final String errorMessage = "Timed out enqueuing event " + event.getClass().getSimpleName() + " - "
 							+ shardId + " (" + consumerArn + ")";
 					LOG.error(errorMessage);
-					onError(new TimeoutException(errorMessage));
+					onError(new RecoverableFanOutSubscriberException(new TimeoutException(errorMessage)));
 				}
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -96,7 +96,7 @@ public class FanOutShardSubscriberTest {
 
 	@Test
 	public void testTimeoutSubscribingToShard() throws Exception {
-		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out acquiring subscription");
 
 		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.failsToAcquireSubscription();
@@ -109,7 +109,7 @@ public class FanOutShardSubscriberTest {
 
 	@Test
 	public void testTimeoutEnqueuingEvent() throws Exception {
-		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
 
 		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.boundedShard()


### PR DESCRIPTION
Backporting bug fixes and improvements from v2.0.3:

* Fix issue where KinesisDataFetcher.shutdownFetcher() hangs. ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/23), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/24))
  
* Log error when shutting down Kinesis Data Fetcher. ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/22), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/25))
  
* Treating TimeoutException as Recoverable Exception. ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/21), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/28))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
