### PR TITLE
Upgrade Guava version

### DIFF
--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
@@ -39,6 +39,7 @@ import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.kinesis.connectors.flink.serialization.KinesisSerializationSchema;
@@ -301,7 +302,7 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 		}
 
 		ListenableFuture<UserRecordResult> cb = producer.addUserRecord(stream, partition, explicitHashkey, serialized);
-		Futures.addCallback(cb, callback);
+		Futures.addCallback(cb, callback, MoreExecutors.directExecutor());
 	}
 
 	@Override

--- a/amazon-kinesis-sql-connector-flink/src/main/resources/META-INF/NOTICE
+++ b/amazon-kinesis-sql-connector-flink/src/main/resources/META-INF/NOTICE
@@ -16,9 +16,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.4
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.10
 - org.apache.commons:commons-lang3:3.3.2
-- com.google.guava:guava:18.0
+- com.google.guava:guava:29.0-jre
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ under the License.
 		<httpcore.version>4.4.11</httpcore.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<flink.version>1.11.2</flink.version>
+		<guava.version>29.0-jre</guava.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
*Description of changes:*

This is for upward compatibility. We were using Guava 18.0 which is quite old
now. Switch to Guava 29.0-jre. And use 3-arg version of Guava addCallback as the
2-arg version is no longer supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
