### PR TITLE
Upgrade Guava version (#35)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@ under the License.
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
+		<guava.version>29.0-jre</guava.version>
 	</properties>
 
 	<scm>

--- a/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
@@ -39,6 +39,7 @@ import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.kinesis.connectors.flink.serialization.KinesisSerializationSchema;
@@ -293,7 +294,7 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 		}
 
 		ListenableFuture<UserRecordResult> cb = producer.addUserRecord(stream, partition, explicitHashkey, serialized);
-		Futures.addCallback(cb, callback);
+		Futures.addCallback(cb, callback, MoreExecutors.directExecutor());
 	}
 
 	@Override

--- a/src/main/resources/META-INF/NOTICE
+++ b/src/main/resources/META-INF/NOTICE
@@ -14,16 +14,16 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.amazonaws:amazon-kinesis-client:1.14.0
 - com.amazonaws:amazon-kinesis-producer:0.14.0
-- com.amazonaws:aws-java-sdk-core:1.11.804
+- com.amazonaws:aws-java-sdk-core:1.11.844
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.844
-- com.amazonaws:aws-java-sdk-kinesis:1.11.804
+- com.amazonaws:aws-java-sdk-kinesis:1.11.844
 - com.amazonaws:aws-java-sdk-kms:1.11.844
 - com.amazonaws:aws-java-sdk-s3:1.11.844
 - com.amazonaws:aws-java-sdk-sts:1.11.844
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.0
 - com.amazonaws:jmespath-java:1.11.844
-- org.apache.httpcomponents:httpclient:4.5.3
-- org.apache.httpcomponents:httpcore:4.4.6
+- org.apache.httpcomponents:httpclient:4.5.9
+- org.apache.httpcomponents:httpcore:4.4.11
 - software.amazon.ion:ion-java:jar:1.0.2
 - software.amazon.awssdk:kinesis:jar:2.13.52
 - software.amazon.awssdk:aws-cbor-protocol:jar:2.13.52
@@ -59,7 +59,7 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:3.11.4
+- com.google.protobuf:protobuf-java:2.6.1
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 

--- a/src/main/resources/META-INF/NOTICE
+++ b/src/main/resources/META-INF/NOTICE
@@ -24,37 +24,37 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:jmespath-java:1.11.844
 - org.apache.httpcomponents:httpclient:4.5.9
 - org.apache.httpcomponents:httpcore:4.4.11
-- software.amazon.ion:ion-java:jar:1.0.2
-- software.amazon.awssdk:kinesis:jar:2.13.52
-- software.amazon.awssdk:aws-cbor-protocol:jar:2.13.52
-- software.amazon.awssdk:aws-json-protocol:jar:2.13.52
-- software.amazon.awssdk:protocol-core:jar:2.13.52
-- software.amazon.awssdk:profiles:jar:2.13.52
-- software.amazon.awssdk:sdk-core:jar:2.13.52
-- software.amazon.awssdk:auth:jar:2.13.52
-- software.amazon.eventstream:eventstream:jar:1.0.1
-- software.amazon.awssdk:http-client-spi:jar:2.13.52
-- software.amazon.awssdk:regions:jar:2.13.52
-- software.amazon.awssdk:annotations:jar:2.13.52
-- software.amazon.awssdk:utils:jar:2.13.52
-- software.amazon.awssdk:aws-core:jar:2.13.52
-- software.amazon.awssdk:metrics-spi:jar:2.13.52
-- software.amazon.awssdk:apache-client:jar:2.13.52
-- software.amazon.awssdk:netty-nio-client:jar:2.13.52
-- software.amazon.awssdk:sts:jar:2.13.52
-- software.amazon.awssdk:aws-query-protocol:jar:2.13.52
-- io.netty:netty-codec-http:jar:4.1.46.Final
-- io.netty:netty-codec-http2:jar:4.1.46.Final
-- io.netty:netty-codec:jar:4.1.46.Final
-- io.netty:netty-transport:jar:4.1.46.Final
-- io.netty:netty-resolver:jar:4.1.46.Final
-- io.netty:netty-common:jar:4.1.46.Final
-- io.netty:netty-buffer:jar:4.1.46.Final
-- io.netty:netty-handler:jar:4.1.46.Final
-- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.46.Final
-- io.netty:netty-transport-native-unix-common:jar:4.1.46.Final
-- com.typesafe.netty:netty-reactive-streams-http:jar:2.0.4
-- com.typesafe.netty:netty-reactive-streams:jar:2.0.4
+- software.amazon.ion:ion-java:1.0.2
+- software.amazon.awssdk:kinesis:2.13.52
+- software.amazon.awssdk:aws-cbor-protocol:2.13.52
+- software.amazon.awssdk:aws-json-protocol:2.13.52
+- software.amazon.awssdk:protocol-core:2.13.52
+- software.amazon.awssdk:profiles:2.13.52
+- software.amazon.awssdk:sdk-core:2.13.52
+- software.amazon.awssdk:auth:2.13.52
+- software.amazon.eventstream:eventstream:1.0.1
+- software.amazon.awssdk:http-client-spi:2.13.52
+- software.amazon.awssdk:regions:2.13.52
+- software.amazon.awssdk:annotations:2.13.52
+- software.amazon.awssdk:utils:2.13.52
+- software.amazon.awssdk:aws-core:2.13.52
+- software.amazon.awssdk:metrics-spi:2.13.52
+- software.amazon.awssdk:apache-client:2.13.52
+- software.amazon.awssdk:netty-nio-client:2.13.52
+- software.amazon.awssdk:sts:2.13.52
+- software.amazon.awssdk:aws-query-protocol:2.13.52
+- io.netty:netty-codec-http:4.1.46.Final
+- io.netty:netty-codec-http2:4.1.46.Final
+- io.netty:netty-codec:4.1.46.Final
+- io.netty:netty-transport:4.1.46.Final
+- io.netty:netty-resolver:4.1.46.Final
+- io.netty:netty-common:4.1.46.Final
+- io.netty:netty-buffer:4.1.46.Final
+- io.netty:netty-handler:4.1.46.Final
+- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.46.Final
+- io.netty:netty-transport-native-unix-common:4.1.46.Final
+- com.typesafe.netty:netty-reactive-streams-http:2.0.4
+- com.typesafe.netty:netty-reactive-streams:2.0.4
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
@@ -63,7 +63,7 @@ See bundled license files for details.
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 
-- org.reactivestreams:reactive-streams:jar:1.0.2
+- org.reactivestreams:reactive-streams:1.0.2
 
 The Amazon Kinesis Producer Library includes http-parser, Copyright (c) Joyent, Inc. and other Node contributors, libc++, Copyright (c) 2003-2014, LLVM Project, and slf4j, Copyright (c) 2004-2013 QOS.ch, each of which is subject to the terms and conditions of the MIT license that states as follows:
 


### PR DESCRIPTION
Switch to 3-arg version of Guava addCallback

This is for upward compatibility. We use Guava 18.0 which is an old
version of Guava. Users who use this library use later versions of Guava
which don't support the 2-arg version. By switching to the 3-arg version
we should become upward compatible without needing to bump up the major
version number of the dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
