### PR TITLE
[FLINK-18182][kinesis] Updating to latest AWS SDK for Kinesis connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,15 @@ under the License.
 	<name>Amazon Kinesis Connector for Apache Flink</name>
 
 	<properties>
-		<aws.sdk.version>1.11.844</aws.sdk.version>
-		<aws.sdkv2.version>2.13.52</aws.sdkv2.version>
+		<aws.sdk.version>1.12.7</aws.sdk.version>
+		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<aws.kinesis-kcl.version>1.14.0</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
-		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
+		<aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
 		<guava.version>29.0-jre</guava.version>
+		<jackson2.version>2.12.1</jackson2.version>
 	</properties>
 
 	<scm>
@@ -63,6 +64,26 @@ under the License.
 				<artifactId>flink-test-utils-junit</artifactId>
 				<version>${project.parent.version}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId> com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson2.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-cbor</artifactId>
+				<version>${jackson2.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -143,6 +164,30 @@ under the License.
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-kms</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-cloudwatch</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-dynamodb</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
 			<version>${aws.kinesis-kpl.version}</version>
 		</dependency>
@@ -151,32 +196,12 @@ under the License.
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-client</artifactId>
 			<version>${aws.kinesis-kcl.version}</version>
-			<!--
-				We're excluding the below from the KCL since we'll only be using the
-				com.amazonaws.services.kinesis.clientlibrary.types.UserRecord class, which will not need these dependencies.
-			-->
-			<exclusions>
-				<exclusion>
-					<groupId>com.amazonaws</groupId>
-					<artifactId>aws-java-sdk-cloudwatch</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>dynamodb-streams-kinesis-adapter</artifactId>
 			<version>${aws.dynamodbstreams-kinesis-adapter.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.amazonaws</groupId>
-					<artifactId>aws-java-sdk-cloudwatch</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Amazon AWS SDK v2.x dependencies -->
@@ -208,13 +233,6 @@ under the License.
 			<artifactId>httpcore</artifactId>
 			<version>${httpcore.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-cbor</artifactId>
-			<version>2.10.1</version>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/src/main/resources/META-INF/NOTICE
+++ b/src/main/resources/META-INF/NOTICE
@@ -14,47 +14,48 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.amazonaws:amazon-kinesis-client:1.14.0
 - com.amazonaws:amazon-kinesis-producer:0.14.0
-- com.amazonaws:aws-java-sdk-core:1.11.844
-- com.amazonaws:aws-java-sdk-dynamodb:1.11.844
-- com.amazonaws:aws-java-sdk-kinesis:1.11.844
-- com.amazonaws:aws-java-sdk-kms:1.11.844
-- com.amazonaws:aws-java-sdk-s3:1.11.844
-- com.amazonaws:aws-java-sdk-sts:1.11.844
-- com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.0
-- com.amazonaws:jmespath-java:1.11.844
+- com.amazonaws:aws-java-sdk-core:1.12.7
+- com.amazonaws:aws-java-sdk-cloudwatch:1.12.7
+- com.amazonaws:aws-java-sdk-dynamodb:1.12.7
+- com.amazonaws:aws-java-sdk-kinesis:1.12.7
+- com.amazonaws:aws-java-sdk-kms:1.12.7
+- com.amazonaws:aws-java-sdk-s3:1.12.7
+- com.amazonaws:aws-java-sdk-sts:1.12.7
+- com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
+- com.amazonaws:jmespath-java:1.12.7
 - org.apache.httpcomponents:httpclient:4.5.9
 - org.apache.httpcomponents:httpcore:4.4.11
 - software.amazon.ion:ion-java:1.0.2
-- software.amazon.awssdk:kinesis:2.13.52
-- software.amazon.awssdk:aws-cbor-protocol:2.13.52
-- software.amazon.awssdk:aws-json-protocol:2.13.52
-- software.amazon.awssdk:protocol-core:2.13.52
-- software.amazon.awssdk:profiles:2.13.52
-- software.amazon.awssdk:sdk-core:2.13.52
-- software.amazon.awssdk:auth:2.13.52
+- software.amazon.awssdk:kinesis:2.16.86
+- software.amazon.awssdk:aws-cbor-protocol:2.16.86
+- software.amazon.awssdk:aws-json-protocol:2.16.86
+- software.amazon.awssdk:protocol-core:2.16.86
+- software.amazon.awssdk:profiles:2.16.86
+- software.amazon.awssdk:sdk-core:2.16.86
+- software.amazon.awssdk:auth:2.16.86
 - software.amazon.eventstream:eventstream:1.0.1
-- software.amazon.awssdk:http-client-spi:2.13.52
-- software.amazon.awssdk:regions:2.13.52
-- software.amazon.awssdk:annotations:2.13.52
-- software.amazon.awssdk:utils:2.13.52
-- software.amazon.awssdk:aws-core:2.13.52
-- software.amazon.awssdk:metrics-spi:2.13.52
-- software.amazon.awssdk:apache-client:2.13.52
-- software.amazon.awssdk:netty-nio-client:2.13.52
-- software.amazon.awssdk:sts:2.13.52
-- software.amazon.awssdk:aws-query-protocol:2.13.52
-- io.netty:netty-codec-http:4.1.46.Final
-- io.netty:netty-codec-http2:4.1.46.Final
-- io.netty:netty-codec:4.1.46.Final
-- io.netty:netty-transport:4.1.46.Final
-- io.netty:netty-resolver:4.1.46.Final
-- io.netty:netty-common:4.1.46.Final
-- io.netty:netty-buffer:4.1.46.Final
-- io.netty:netty-handler:4.1.46.Final
-- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.46.Final
-- io.netty:netty-transport-native-unix-common:4.1.46.Final
-- com.typesafe.netty:netty-reactive-streams-http:2.0.4
-- com.typesafe.netty:netty-reactive-streams:2.0.4
+- software.amazon.awssdk:http-client-spi:2.16.86
+- software.amazon.awssdk:regions:2.16.86
+- software.amazon.awssdk:annotations:2.16.86
+- software.amazon.awssdk:utils:2.16.86
+- software.amazon.awssdk:aws-core:2.16.86
+- software.amazon.awssdk:metrics-spi:2.16.86
+- software.amazon.awssdk:apache-client:2.16.86
+- software.amazon.awssdk:netty-nio-client:2.16.86
+- software.amazon.awssdk:sts:2.16.86
+- software.amazon.awssdk:aws-query-protocol:2.16.86
+- io.netty:netty-codec-http:4.1.63.Final
+- io.netty:netty-codec-http2:4.1.63.Final
+- io.netty:netty-codec:4.1.63.Final
+- io.netty:netty-transport:4.1.63.Final
+- io.netty:netty-resolver:4.1.63.Final
+- io.netty:netty-common:4.1.63.Final
+- io.netty:netty-buffer:4.1.63.Final
+- io.netty:netty-handler:4.1.63.Final
+- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.63.Final
+- io.netty:netty-transport-native-unix-common:4.1.63.Final
+- com.typesafe.netty:netty-reactive-streams-http:2.0.5
+- com.typesafe.netty:netty-reactive-streams:2.0.5
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
@@ -63,7 +64,7 @@ See bundled license files for details.
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 
-- org.reactivestreams:reactive-streams:1.0.2
+- org.reactivestreams:reactive-streams:1.0.3
 
 The Amazon Kinesis Producer Library includes http-parser, Copyright (c) Joyent, Inc. and other Node contributors, libc++, Copyright (c) 2003-2014, LLVM Project, and slf4j, Copyright (c) 2004-2013 QOS.ch, each of which is subject to the terms and conditions of the MIT license that states as follows:
 

--- a/src/main/resources/software/amazon/kinesis/shaded/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/src/main/resources/software/amazon/kinesis/shaded/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+software.amazon.kinesis.shaded.software.amazon.awssdk.core.internal.interceptor.HttpChecksumRequiredInterceptor


### PR DESCRIPTION
*Description of changes:*
- Update AWS SDK v1 to `v1.12.7`
- Update AWS SDK v2 to `v2.12.1`
- Update DynamoDB Stream adapter to `v1.5.3`
- Update Jackson to `v2.12.1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
