### PR TITLE
Include guava:failureaccess in jar

### DIFF
--- a/amazon-kinesis-sql-connector-flink/pom.xml
+++ b/amazon-kinesis-sql-connector-flink/pom.xml
@@ -83,6 +83,7 @@ under the License.
 									<include>commons-logging:commons-logging</include>
 									<include>org.apache.commons:commons-lang3</include>
 									<include>com.google.guava:guava</include>
+									<include>com.google.guava:failureaccess</include>
 								</includes>
 							</artifactSet>
 							<filters>

--- a/amazon-kinesis-sql-connector-flink/src/main/resources/META-INF/NOTICE
+++ b/amazon-kinesis-sql-connector-flink/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.10
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
+- com.google.guava:failureaccess:1.0.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1


### PR DESCRIPTION
*Issue #, if available:* Related to https://issues.apache.org/jira/browse/FLINK-23009

*Description of changes:*

This is a runtime dependency without which we get exceptions
in flink kinesis sql connector.
