### PR TITLE
Refactor to prevent AWS SDK/Netty threads blocking

### DIFF
--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriber.java
@@ -89,7 +89,7 @@ public class FanOutShardSubscriber {
 	 * The queue is mainly used to isolate networking from consumption such that errors do not bubble up.
 	 * This queue also acts as a buffer resulting in a record prefetch and reduced latency.
 	 */
-	private static final int QUEUE_CAPACITY = 1;
+	private static final int QUEUE_CAPACITY = 2;
 
 	/**
 	 * Read timeout will occur after 30 seconds, a sanity timeout to prevent lockup in unexpected error states.
@@ -321,6 +321,9 @@ public class FanOutShardSubscriber {
 				result = false;
 				break;
 			} else if (subscriptionEvent.isSubscribeToShardEvent()) {
+				// Request for KDS to send the next record batch
+				subscription.requestRecord();
+
 				SubscribeToShardEvent event = subscriptionEvent.getSubscribeToShardEvent();
 				continuationSequenceNumber = event.continuationSequenceNumber();
 				if (!event.records().isEmpty()) {
@@ -380,7 +383,6 @@ public class FanOutShardSubscriber {
 				@Override
 				public void visit(SubscribeToShardEvent event) {
 					enqueueEvent(new SubscriptionNextEvent(event));
-					requestRecord();
 				}
 			});
 		}

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
@@ -95,7 +95,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 		assertTrue(fetcher.isRunning());
 	}
 
-	@Test(timeout = 1000)
+	@Test(timeout = 10_000)
 	public void testIsRunningFalseAfterShutDown() throws InterruptedException {
 		KinesisDataFetcher<String> fetcher = createTestDataFetcherWithNoShards(10, 2, "test-stream");
 

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -117,9 +117,7 @@ public class FanOutShardSubscriberTest {
 		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
 
-		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.boundedShard()
-				.withBatchCount(5)
-				.build();
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.shardThatCreatesBackpressureOnQueue();
 
 		FanOutShardSubscriber subscriber = new FanOutShardSubscriber(
 				"consumerArn",

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -44,15 +44,21 @@ import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyV2Interface;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static software.amazon.awssdk.services.kinesis.model.ConsumerStatus.ACTIVE;
 import static software.amazon.awssdk.services.kinesis.model.ConsumerStatus.CREATING;
@@ -99,6 +105,10 @@ public class FakeKinesisFanOutBehavioursFactory {
 		return new FailsToAcquireSubscriptionKinesis();
 	}
 
+	public static AbstractSingleShardFanOutKinesisV2 shardThatCreatesBackpressureOnQueue() {
+		return new MultipleEventsForSingleRequest();
+	}
+
 	// ------------------------------------------------------------------------
 	//  Behaviours related to describing streams
 	// ------------------------------------------------------------------------
@@ -131,20 +141,21 @@ public class FakeKinesisFanOutBehavioursFactory {
 
 	public static AbstractSingleShardFanOutKinesisV2 emptyBatchFollowedBySingleRecord() {
 		return new AbstractSingleShardFanOutKinesisV2(2) {
-			private int subscription = 0;
+			private int subscriptionCount = 0;
 
 			@Override
-			void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
+			List<SubscribeToShardEvent> getEventsToSend() {
 				SubscribeToShardEvent.Builder builder = SubscribeToShardEvent
 					.builder()
-					.continuationSequenceNumber(subscription == 0 ? "1" : null);
+					.continuationSequenceNumber(subscriptionCount == 0 ? "1" : null);
 
-				if (subscription == 1) {
+				if (subscriptionCount == 1) {
 					builder.records(createRecord(new AtomicInteger(1)));
 				}
 
-				subscriber.onNext(builder.build());
-				subscription++;
+				subscriptionCount++;
+
+				return Collections.singletonList(builder.build());
 			}
 		};
 	}
@@ -162,15 +173,14 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		@Override
-		void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
-			if (index % 2 == 0) {
-				super.sendEvents(subscriber);
+		void completeSubscription(Subscriber<? super SubscribeToShardEventStream> subscriber) {
+			if (index++ % 2 == 0) {
+				// Fail the subscription
+				super.completeSubscription(subscriber);
 			} else {
-				super.sendEventBatch(subscriber);
+				// Do not fail the subscription
 				subscriber.onComplete();
 			}
-
-			index++;
 		}
 	}
 
@@ -194,26 +204,21 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		@Override
-		void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
-			sendEventBatch(subscriber);
+		List<SubscribeToShardEvent> getEventsToSend() {
+			return generateEvents(NUMBER_OF_EVENTS_PER_SUBSCRIPTION, sequenceNumber);
+		}
+
+		@Override
+		void completeSubscription(Subscriber<? super SubscribeToShardEventStream> subscriber) {
 			try {
 				// Add an artificial delay to allow records to flush
 				Thread.sleep(200);
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
+
 			for (Throwable throwable : throwables) {
 				subscriber.onError(throwable);
-			}
-		}
-
-		void sendEventBatch(Subscriber<? super SubscribeToShardEventStream> subscriber) {
-			for (int i = 0; i < NUMBER_OF_EVENTS_PER_SUBSCRIPTION; i++) {
-				subscriber.onNext(SubscribeToShardEvent
-					.builder()
-					.records(createRecord(sequenceNumber))
-					.continuationSequenceNumber(String.valueOf(i))
-					.build());
 			}
 		}
 	}
@@ -243,9 +248,28 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		@Override
-		void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
-			subscriber.onNext(event);
+		List<SubscribeToShardEvent> getEventsToSend() {
+			return Collections.singletonList(event);
 		}
+	}
+
+	private static class MultipleEventsForSingleRequest extends AbstractSingleShardFanOutKinesisV2 {
+
+		private MultipleEventsForSingleRequest() {
+			super(1);
+		}
+
+		@Override
+		List<SubscribeToShardEvent> getEventsToSend() {
+			return generateEvents(2, new AtomicInteger(1));
+		}
+
+		@Override
+		void completeSubscription(Subscriber<? super SubscribeToShardEventStream> subscriber) {
+			generateEvents(3, new AtomicInteger(2)).forEach(subscriber::onNext);
+			super.completeSubscription(subscriber);
+		}
+
 	}
 
 	/**
@@ -276,7 +300,9 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		@Override
-		void sendEvents(final Subscriber<? super SubscribeToShardEventStream> subscriber) {
+		List<SubscribeToShardEvent> getEventsToSend() {
+			List<SubscribeToShardEvent> events = new ArrayList<>();
+
 			SubscribeToShardEvent.Builder eventBuilder = SubscribeToShardEvent
 				.builder()
 				.millisBehindLatest(millisBehindLatest);
@@ -301,8 +327,10 @@ public class FakeKinesisFanOutBehavioursFactory {
 				String continuation = sequenceNumber.get() < totalRecords ? String.valueOf(sequenceNumber.get() + 1) : null;
 				eventBuilder.continuationSequenceNumber(continuation);
 
-				subscriber.onNext(eventBuilder.build());
+				events.add(eventBuilder.build());
 			}
+
+			return events;
 		}
 
 		/**
@@ -401,30 +429,44 @@ public class FakeKinesisFanOutBehavioursFactory {
 
 			return CompletableFuture.supplyAsync(() -> {
 				responseHandler.responseReceived(SubscribeToShardResponse.builder().build());
-
 				responseHandler.onEventStream(subscriber -> {
-					subscriber.onSubscribe(mock(Subscription.class));
+					final List<SubscribeToShardEvent> eventsToSend;
 
 					if (remainingSubscriptions > 0) {
-						sendEvents(subscriber);
+						eventsToSend = getEventsToSend();
 						remainingSubscriptions--;
 					} else {
-						SubscribeToShardEvent.Builder eventBuilder = SubscribeToShardEvent
-							.builder()
-							.millisBehindLatest(0L)
-							.continuationSequenceNumber(null);
-
-						subscriber.onNext(eventBuilder.build());
+						eventsToSend = Collections.singletonList(SubscribeToShardEvent
+								.builder()
+								.millisBehindLatest(0L)
+								.continuationSequenceNumber(null)
+								.build());
 					}
 
-					subscriber.onComplete();
-				});
+					Subscription subscription = mock(Subscription.class);
+					Iterator<SubscribeToShardEvent> iterator = eventsToSend.iterator();
 
+					doAnswer(a -> {
+						if (!iterator.hasNext()) {
+							completeSubscription(subscriber);
+						} else {
+							subscriber.onNext(iterator.next());
+						}
+
+						return null;
+					}).when(subscription).request(anyLong());
+
+					subscriber.onSubscribe(subscription);
+				});
 				return null;
 			});
 		}
 
-		abstract void sendEvents(final Subscriber<? super SubscribeToShardEventStream> subscriber);
+		void completeSubscription(Subscriber<? super SubscribeToShardEventStream> subscriber) {
+			subscriber.onComplete();
+		}
+
+		abstract List<SubscribeToShardEvent> getEventsToSend();
 
 	}
 
@@ -614,6 +656,16 @@ public class FakeKinesisFanOutBehavioursFactory {
 		}
 
 		return createRecord(recordAggregator.clearAndGet().toRecordBytes(), sequenceNumber);
+	}
+
+	private static List<SubscribeToShardEvent> generateEvents(int numberOfEvents, AtomicInteger sequenceNumber) {
+		return IntStream.range(0, numberOfEvents)
+				.mapToObj(i -> SubscribeToShardEvent
+						.builder()
+						.records(createRecord(sequenceNumber))
+						.continuationSequenceNumber(String.valueOf(i))
+						.build())
+				.collect(Collectors.toList());
 	}
 
 }


### PR DESCRIPTION
Description of changes:
- Moving "request record" from the SDK async response thread to the shard consumer to prevent SDK/Netty threads from blocking in connector code.
- Increased inter-thread communication queue to 2 to allow completion events to be added to queue without blocking.
- Refactoring test Kinesis implementation to wait for "request record" before sending record batches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
