### PR TITLE
Increasing read timeout to 6 minutes and enabling TCP keep alive for EFO

### DIFF
--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
@@ -240,6 +240,10 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String EFO_HTTP_CLIENT_MAX_CONCURRENCY = "flink.stream.efo.http-client.max-concurrency";
 
+	public static final String EFO_HTTP_CLIENT_READ_TIMEOUT_MILLIS = "flink.stream.efo.http-client.read-timeout";
+
+	public static final String EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT_MILLIS = "flink.stream.efo.http-client.acquisition-timeout";
+
 	// ------------------------------------------------------------------------
 	//  Default values for consumer configuration
 	// ------------------------------------------------------------------------
@@ -330,7 +334,11 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
 
-	public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
+	public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY = 10_000;
+
+	public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
+
+	public static final Duration DEFAULT_EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT = Duration.ofMinutes(1);
 
 	/**
 	 * To avoid shard iterator expires in {@link ShardConsumer}s, the value for the configured

--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -165,7 +165,7 @@ public class FanOutRecordPublisher implements RecordPublisher {
 			}
 
 			if (attempt == configuration.getSubscribeToShardMaxRetries()) {
-				final String errorMessage = "Maximum reties exceeded for SubscribeToShard. " +
+				final String errorMessage = "Maximum retries exceeded for SubscribeToShard. " +
 					"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.";
 				LOG.error(errorMessage, ex.getCause());
 				throw new RuntimeException(errorMessage, ex.getCause());

--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
@@ -53,6 +53,7 @@ public class KinesisProxyV2Factory {
 		Preconditions.checkNotNull(configProps);
 
 		final ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		populateDefaultValues(clientConfiguration);
 		AWSUtil.setAwsClientConfigProperties(clientConfiguration, configProps);
 
 		final SdkAsyncHttpClient httpClient = AwsV2Util.createHttpClient(clientConfiguration, NettyNioAsyncHttpClient.builder(), configProps);
@@ -60,6 +61,10 @@ public class KinesisProxyV2Factory {
 		final KinesisAsyncClient client = AwsV2Util.createKinesisAsyncClient(configProps, clientConfiguration, httpClient);
 
 		return new KinesisProxyV2(client, httpClient, configuration, BACKOFF);
+	}
+
+	private static void populateDefaultValues(final ClientConfiguration clientConfiguration) {
+		clientConfiguration.setUseTcpKeepAlive(true);
 	}
 
 }

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
@@ -264,7 +264,7 @@ public class FanOutRecordPublisherTest {
 	@Test
 	public void testSubscribeToShardFailsWhenMaxRetriesExceeded() throws Exception {
 		thrown.expect(RuntimeException.class);
-		thrown.expectMessage("Maximum reties exceeded for SubscribeToShard. Failed 3 times.");
+		thrown.expectMessage("Maximum retries exceeded for SubscribeToShard. Failed 3 times.");
 
 		Properties efoProperties = createEfoProperties();
 		efoProperties.setProperty(SUBSCRIBE_TO_SHARD_RETRIES, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_RETRIES));

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static software.amazon.kinesis.connectors.flink.util.AWSUtil.AWS_CLIENT_CONFIG_PREFIX;
 
 /**
@@ -55,6 +57,27 @@ public class KinesisProxyV2FactoryTest {
 		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
 
 		assertEquals(12345, nettyConfiguration.connectTimeoutMillis());
+	}
+
+	@Test
+	public void testClientConfigurationPopulatedTcpKeepAliveDefaults() throws Exception {
+		Properties properties = properties();
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertTrue(nettyConfiguration.tcpKeepAlive());
+	}
+
+	@Test
+	public void testClientConfigurationPopulatedTcpKeepAliveFromProperties() throws Exception {
+		Properties properties = properties();
+		properties.setProperty(AWS_CLIENT_CONFIG_PREFIX + "useTcpKeepAlive", "false");
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertFalse(nettyConfiguration.tcpKeepAlive());
 	}
 
 	private NettyConfiguration getNettyConfiguration(final KinesisProxyV2Interface kinesis) throws Exception {


### PR DESCRIPTION
*Description of changes:*

- Increasing read timeout to 6 minutes
- Enabling TCP keep alive
- Externalising read timeout, acquisition timeout and TCP keep alive to allow customers to override

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
