### PR TITLE
Unregistering metric reporting for closed shards

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumer.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumer.java
@@ -138,6 +138,8 @@ public class ShardConsumer<T> implements Runnable {
 			}
 		} catch (Throwable t) {
 			fetcherRef.stopWithError(t);
+		} finally {
+			this.shardConsumerMetricsReporter.unregister();
 		}
 	}
 

--- a/src/main/java/software/amazon/kinesis/connectors/flink/metrics/ShardConsumerMetricsReporter.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/metrics/ShardConsumerMetricsReporter.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.metrics;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 
 import software.amazon.kinesis.connectors.flink.internals.ShardConsumer;
 
@@ -31,12 +32,15 @@ import software.amazon.kinesis.connectors.flink.internals.ShardConsumer;
 @Internal
 public class ShardConsumerMetricsReporter {
 
+	private final MetricGroup metricGroup;
+
 	private volatile long millisBehindLatest = -1;
 	private volatile long averageRecordSizeBytes = 0L;
 	private volatile int numberOfAggregatedRecords = 0;
 	private volatile int numberOfDeaggregatedRecords = 0;
 
 	public ShardConsumerMetricsReporter(final MetricGroup metricGroup) {
+		this.metricGroup = metricGroup;
 		metricGroup.gauge(KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE, this::getMillisBehindLatest);
 		metricGroup.gauge(KinesisConsumerMetricConstants.NUM_AGGREGATED_RECORDS_PER_FETCH, this::getNumberOfAggregatedRecords);
 		metricGroup.gauge(KinesisConsumerMetricConstants.NUM_DEAGGREGATED_RECORDS_PER_FETCH, this::getNumberOfDeaggregatedRecords);
@@ -75,4 +79,9 @@ public class ShardConsumerMetricsReporter {
 		this.numberOfDeaggregatedRecords = numberOfDeaggregatedRecords;
 	}
 
+	public void unregister() {
+		if (this.metricGroup instanceof AbstractMetricGroup) {
+			((AbstractMetricGroup) this.metricGroup).close();
+		}
+	}
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/DynamoDBStreamsDataFetcherTest.java
@@ -18,6 +18,7 @@ package software.amazon.kinesis.connectors.flink.internals;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 
 import org.junit.Test;
 import software.amazon.kinesis.connectors.flink.model.StreamShardHandle;
@@ -33,6 +34,7 @@ import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static software.amazon.kinesis.connectors.flink.internals.KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 
 /**
@@ -59,7 +61,7 @@ public class DynamoDBStreamsDataFetcherTest {
 		fetcher.createRecordPublisher(
 				SENTINEL_LATEST_SEQUENCE_NUM.get(),
 				new Properties(),
-				runtimeContext.getMetricGroup(),
+				createFakeShardConsumerMetricGroup((OperatorMetricGroup) runtimeContext.getMetricGroup()),
 				dummyStreamShardHandle);
 
 		verify(kinesis).getShardIterator(dummyStreamShardHandle, LATEST.toString(), null);

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/ShardConsumerTest.java
@@ -19,6 +19,8 @@
 
 package software.amazon.kinesis.connectors.flink.internals;
 
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+
 import org.junit.Test;
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.polling.PollingRecordPublisherFactory;
@@ -32,12 +34,14 @@ import java.util.Date;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.fakeSequenceNumber;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
@@ -53,6 +57,21 @@ public class ShardConsumerTest {
 
 		ShardConsumerMetricsReporter metrics = assertNumberOfMessagesReceivedFromKinesis(500, kinesis, fakeSequenceNumber());
 		assertEquals(500, metrics.getMillisBehindLatest());
+	}
+
+	@Test
+	public void testConsumerAndProducerMetricsAreUnregisteredAfterShardCompletes() throws Exception {
+		KinesisProxyInterface kinesis = FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(
+				500,
+				5,
+				500);
+		AbstractMetricGroup metricGroup = createFakeShardConsumerMetricGroup();
+		assertNumberOfMessagesReceivedFromKinesis(
+				500,
+				kinesis,
+				fakeSequenceNumber(),
+				metricGroup);
+		assertTrue(metricGroup.isClosed());
 	}
 
 	@Test
@@ -162,6 +181,19 @@ public class ShardConsumerTest {
 			final KinesisProxyInterface kinesis,
 			final SequenceNumber startingSequenceNumber) throws Exception {
 		return assertNumberOfMessagesReceivedFromKinesis(expectedNumberOfMessages, kinesis, startingSequenceNumber, new Properties());
+	}
+
+	private ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+			final int expectedNumberOfMessages,
+			final KinesisProxyInterface kinesis,
+			final SequenceNumber startingSequenceNumber,
+			final AbstractMetricGroup metricGroup) throws Exception {
+		return ShardConsumerTestUtils.assertNumberOfMessagesReceivedFromKinesis(
+				expectedNumberOfMessages,
+				new PollingRecordPublisherFactory(config -> kinesis),
+				startingSequenceNumber,
+				new Properties(),
+				metricGroup);
 	}
 
 	private ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
@@ -19,8 +19,6 @@
 
 package software.amazon.kinesis.connectors.flink.internals.publisher.polling;
 
-import org.apache.flink.metrics.MetricGroup;
-
 import org.junit.Test;
 import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher;
@@ -33,6 +31,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 
 /**
@@ -47,7 +46,7 @@ public class PollingRecordPublisherFactoryTest {
 		RecordPublisher recordPublisher = factory.create(
 			StartingPosition.restartFromSequenceNumber(SENTINEL_LATEST_SEQUENCE_NUM.get()),
 			new Properties(),
-			mock(MetricGroup.class),
+			createFakeShardConsumerMetricGroup(),
 			mock(StreamShardHandle.class));
 
 		assertTrue(recordPublisher instanceof PollingRecordPublisher);
@@ -62,7 +61,7 @@ public class PollingRecordPublisherFactoryTest {
 		RecordPublisher recordPublisher = factory.create(
 			StartingPosition.restartFromSequenceNumber(SENTINEL_LATEST_SEQUENCE_NUM.get()),
 			properties,
-			mock(MetricGroup.class),
+			createFakeShardConsumerMetricGroup(),
 			mock(StreamShardHandle.class));
 
 		assertTrue(recordPublisher instanceof PollingRecordPublisher);

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -19,8 +19,6 @@
 
 package software.amazon.kinesis.connectors.flink.internals.publisher.polling;
 
-import org.apache.flink.metrics.MetricGroup;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
 import static software.amazon.kinesis.connectors.flink.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
@@ -69,7 +68,7 @@ public class PollingRecordPublisherTest {
 	@Test
 	public void testRunEmitsRunLoopTimeNanos() throws Exception {
 		PollingRecordPublisherMetricsReporter metricsReporter =
-				spy(new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class)));
+				spy(new PollingRecordPublisherMetricsReporter(createFakeShardConsumerMetricGroup()));
 
 		KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 5, 100);
 		PollingRecordPublisher recordPublisher =
@@ -151,7 +150,7 @@ public class PollingRecordPublisherTest {
 	PollingRecordPublisher createPollingRecordPublisher(final KinesisProxyInterface kinesis)
 			throws Exception {
 		PollingRecordPublisherMetricsReporter metricsReporter =
-				new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class));
+				new PollingRecordPublisherMetricsReporter(createFakeShardConsumerMetricGroup());
 
 		return createPollingRecordPublisher(kinesis, metricsReporter);
 	}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/metrics/ShardConsumerMetricsReporterTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/metrics/ShardConsumerMetricsReporterTest.java
@@ -20,14 +20,17 @@
 package software.amazon.kinesis.connectors.flink.metrics;
 
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import software.amazon.kinesis.connectors.flink.internals.ShardConsumerTestUtils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -67,5 +70,16 @@ public class ShardConsumerMetricsReporterTest {
 		assertEquals(2, metricsReporter.getMillisBehindLatest());
 		assertEquals(3, metricsReporter.getNumberOfAggregatedRecords());
 		assertEquals(4, metricsReporter.getNumberOfDeaggregatedRecords());
+	}
+
+	@Test
+	public void testUnregister() {
+		AbstractMetricGroup metricGroup = ShardConsumerTestUtils
+				.createFakeShardConsumerMetricGroup();
+		ShardConsumerMetricsReporter metricsReporter = new ShardConsumerMetricsReporter(metricGroup);
+
+		metricsReporter.unregister();
+
+		assertTrue(metricGroup.isClosed());
 	}
 }

--- a/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestUtils.java
@@ -21,7 +21,6 @@ package software.amazon.kinesis.connectors.flink.testutils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import com.amazonaws.kinesis.agg.AggRecord;
 import com.amazonaws.kinesis.agg.RecordAggregator;
@@ -49,6 +48,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -147,7 +147,7 @@ public class TestUtils {
 		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
 				Thread.currentThread().getContextClassLoader());
 
-		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
+		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(createUnregisteredOperatorMetricGroup());
 
 		return mockedRuntimeContext;
 	}


### PR DESCRIPTION
*Description of changes:*
Unregister metric reports for closed/complete shards. Fixes a bug where confusing aggregated metrics are shown after resharding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
