### PR TITLE
Backport v2.2.0 fixes to v1.x

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/config/ConsumerConfigConstants.java
@@ -240,6 +240,10 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String EFO_HTTP_CLIENT_MAX_CONCURRENCY = "flink.stream.efo.http-client.max-concurrency";
 
+	public static final String EFO_HTTP_CLIENT_READ_TIMEOUT_MILLIS = "flink.stream.efo.http-client.read-timeout";
+
+	public static final String EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT_MILLIS = "flink.stream.efo.http-client.acquisition-timeout";
+
 	// ------------------------------------------------------------------------
 	//  Default values for consumer configuration
 	// ------------------------------------------------------------------------
@@ -330,7 +334,11 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
 
-	public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
+	public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY = 10_000;
+
+	public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
+
+	public static final Duration DEFAULT_EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT = Duration.ofMinutes(1);
 
 	/**
 	 * To avoid shard iterator expires in {@link ShardConsumer}s, the value for the configured

--- a/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -163,7 +163,7 @@ public class FanOutRecordPublisher implements RecordPublisher {
 			}
 
 			if (attempt == configuration.getSubscribeToShardMaxRetries()) {
-				final String errorMessage = "Maximum reties exceeded for SubscribeToShard. " +
+				final String errorMessage = "Maximum retries exceeded for SubscribeToShard. " +
 						"Failed " + configuration.getSubscribeToShardMaxRetries() + " times.";
 				LOG.error(errorMessage, ex.getCause());
 				throw new RuntimeException(errorMessage, ex.getCause());

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
@@ -53,6 +53,7 @@ public class KinesisProxyV2Factory {
 		Preconditions.checkNotNull(configProps);
 
 		final ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		populateDefaultValues(clientConfiguration);
 		AWSUtil.setAwsClientConfigProperties(clientConfiguration, configProps);
 
 		final SdkAsyncHttpClient httpClient = AwsV2Util.createHttpClient(clientConfiguration, NettyNioAsyncHttpClient.builder(), configProps);
@@ -60,6 +61,10 @@ public class KinesisProxyV2Factory {
 		final KinesisAsyncClient client = AwsV2Util.createKinesisAsyncClient(configProps, clientConfiguration, httpClient);
 
 		return new KinesisProxyV2(client, httpClient, configuration, BACKOFF);
+	}
+
+	private static void populateDefaultValues(final ClientConfiguration clientConfiguration) {
+		clientConfiguration.setUseTcpKeepAlive(true);
 	}
 
 }

--- a/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2Factory.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutRecordPublisherConfiguration;
+import software.amazon.kinesis.connectors.flink.util.AWSUtil;
 import software.amazon.kinesis.connectors.flink.util.AwsV2Util;
 
 import java.util.Properties;
@@ -52,6 +53,8 @@ public class KinesisProxyV2Factory {
 		Preconditions.checkNotNull(configProps);
 
 		final ClientConfiguration clientConfiguration = new ClientConfigurationFactory().getConfig();
+		AWSUtil.setAwsClientConfigProperties(clientConfiguration, configProps);
+
 		final SdkAsyncHttpClient httpClient = AwsV2Util.createHttpClient(clientConfiguration, NettyNioAsyncHttpClient.builder(), configProps);
 		final FanOutRecordPublisherConfiguration configuration = new FanOutRecordPublisherConfiguration(configProps, emptyList());
 		final KinesisAsyncClient client = AwsV2Util.createKinesisAsyncClient(configProps, clientConfiguration, httpClient);

--- a/src/main/java/software/amazon/kinesis/connectors/flink/util/AwsV2Util.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/util/AwsV2Util.java
@@ -54,6 +54,12 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEFAULT_EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT_MILLIS;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_HTTP_CLIENT_READ_TIMEOUT_MILLIS;
+
 /**
  * Utility methods specific to Amazon Web Service SDK v2.x.
  */
@@ -62,7 +68,6 @@ public class AwsV2Util {
 
 	private static final int INITIAL_WINDOW_SIZE_BYTES = 512 * 1024; // 512 KB
 	private static final Duration HEALTH_CHECK_PING_PERIOD = Duration.ofSeconds(60);
-	private static final Duration CONNECTION_ACQUISITION_TIMEOUT = Duration.ofSeconds(60);
 
 	/**
 	 * Creates an Amazon Kinesis Async Client from the provided properties.
@@ -92,16 +97,30 @@ public class AwsV2Util {
 		int maxConcurrency = Optional
 			.ofNullable(consumerConfig.getProperty(ConsumerConfigConstants.EFO_HTTP_CLIENT_MAX_CONCURRENCY))
 			.map(Integer::parseInt)
-			.orElse(ConsumerConfigConstants.DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY);
+			.orElse(DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY);
+
+		Duration readTimeout = Optional
+				.ofNullable(consumerConfig.getProperty(EFO_HTTP_CLIENT_READ_TIMEOUT_MILLIS))
+				.map(Integer::parseInt)
+				.map(Duration::ofMillis)
+				.orElse(DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT);
+
+		Duration acquisitionTimeout = Optional
+				.ofNullable(consumerConfig.getProperty(EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT_MILLIS))
+				.map(Integer::parseInt)
+				.map(Duration::ofMillis)
+				.orElse(DEFAULT_EFO_HTTP_CLIENT_ACQUISITION_TIMEOUT);
 
 		httpClientBuilder
 			.maxConcurrency(maxConcurrency)
 			.connectionTimeout(Duration.ofMillis(config.getConnectionTimeout()))
+			.readTimeout(readTimeout)
+			.tcpKeepAlive(config.useTcpKeepAlive())
 			.writeTimeout(Duration.ofMillis(config.getSocketTimeout()))
 			.connectionMaxIdleTime(Duration.ofMillis(config.getConnectionMaxIdleMillis()))
 			.useIdleConnectionReaper(config.useReaper())
 			.protocol(Protocol.HTTP2)
-			.connectionAcquisitionTimeout(CONNECTION_ACQUISITION_TIMEOUT)
+			.connectionAcquisitionTimeout(acquisitionTimeout)
 			.http2Configuration(Http2Configuration
 				.builder()
 				.healthCheckPingPeriod(HEALTH_CHECK_PING_PERIOD)

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcherTest.java
@@ -95,7 +95,7 @@ public class KinesisDataFetcherTest extends TestLogger {
 		assertTrue(fetcher.isRunning());
 	}
 
-	@Test(timeout = 1000)
+	@Test(timeout = 10_000)
 	public void testIsRunningFalseAfterShutDown() throws InterruptedException {
 		KinesisDataFetcher<String> fetcher = createTestDataFetcherWithNoShards(10, 2, "test-stream");
 

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
@@ -253,7 +253,7 @@ public class FanOutRecordPublisherTest {
 	@Test
 	public void testSubscribeToShardFailsWhenMaxRetriesExceeded() throws Exception {
 		thrown.expect(RuntimeException.class);
-		thrown.expectMessage("Maximum reties exceeded for SubscribeToShard. Failed 3 times.");
+		thrown.expectMessage("Maximum retries exceeded for SubscribeToShard. Failed 3 times.");
 
 		Properties efoProperties = createEfoProperties();
 		efoProperties.setProperty(ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES, String.valueOf(EXPECTED_SUBSCRIBE_TO_SHARD_RETRIES));

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutRecordPublisherTest.java
@@ -71,6 +71,7 @@ import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.AT
 import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.LATEST;
 import static software.amazon.awssdk.services.kinesis.model.ShardIteratorType.TRIM_HORIZON;
 import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.CANCELLED;
+import static software.amazon.kinesis.connectors.flink.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
 
 /**
  * Tests for {@link FanOutRecordPublisher}.
@@ -217,15 +218,14 @@ public class FanOutRecordPublisherTest {
 		RecordPublisher recordPublisher = createRecordPublisher(kinesis);
 		TestConsumer consumer = new TestConsumer();
 
-		int count = 0;
-		while (recordPublisher.run(consumer) == RecordPublisher.RecordPublisherRunResult.INCOMPLETE) {
-			if (++count > FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2.NUMBER_OF_SUBSCRIPTIONS + 1) {
-				break;
-			}
-		}
+		RecordPublisherRunResult result = recordPublisher.run(consumer);
 
-		// An exception is thrown on the 5th subscription and then the subscription completes on the next
-		Assert.assertEquals(FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2.NUMBER_OF_SUBSCRIPTIONS + 1, kinesis.getNumberOfSubscribeToShardInvocations());
+		// An exception is thrown after the 5th record in each subscription, therefore we expect to receive 5 records
+		assertEquals(5, consumer.getRecordBatches().size());
+		assertEquals(1, kinesis.getNumberOfSubscribeToShardInvocations());
+
+		// INCOMPLETE is returned to indicate the shard is not complete
+		assertEquals(INCOMPLETE, result);
 	}
 
 	@Test

--- a/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -112,9 +112,7 @@ public class FanOutShardSubscriberTest {
 		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
 		thrown.expectMessage("Timed out enqueuing event SubscriptionNextEvent");
 
-		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.boundedShard()
-				.withBatchCount(5)
-				.build();
+		KinesisProxyV2Interface kinesis = FakeKinesisFanOutBehavioursFactory.shardThatCreatesBackpressureOnQueue();
 
 		FanOutShardSubscriber subscriber = new FanOutShardSubscriber(
 				"consumerArn",

--- a/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.connectors.flink.proxy;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
+import org.junit.Test;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
+import software.amazon.kinesis.connectors.flink.config.AWSConfigConstants;
+import software.amazon.kinesis.connectors.flink.testutils.TestUtils;
+
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static software.amazon.kinesis.connectors.flink.util.AWSUtil.AWS_CLIENT_CONFIG_PREFIX;
+
+/**
+ * Test for methods in the {@link KinesisProxyV2Factory} class.
+ */
+public class KinesisProxyV2FactoryTest {
+
+	@Test
+	public void testClientConfigurationPopulatedFromDefaults() throws Exception {
+		Properties properties = properties();
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertEquals(defaultClientConfiguration().getConnectionTimeout(), nettyConfiguration.connectTimeoutMillis());
+	}
+
+	@Test
+	public void testClientConfigurationPopulatedFromProperties() throws Exception {
+		Properties properties = properties();
+		properties.setProperty(AWS_CLIENT_CONFIG_PREFIX + "connectionTimeout", "12345");
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertEquals(12345, nettyConfiguration.connectTimeoutMillis());
+	}
+
+	private NettyConfiguration getNettyConfiguration(final KinesisProxyV2Interface kinesis) throws Exception {
+		NettyNioAsyncHttpClient httpClient = getField("httpClient", kinesis);
+		return getField("configuration", httpClient);
+	}
+
+	private <T> T getField(String fieldName, Object obj) throws Exception {
+		Field field = obj.getClass().getDeclaredField(fieldName);
+		field.setAccessible(true);
+		return (T) field.get(obj);
+	}
+
+	private ClientConfiguration defaultClientConfiguration() {
+		return new ClientConfigurationFactory().getConfig();
+	}
+
+	private Properties properties() {
+		Properties properties = TestUtils.efoProperties();
+		properties.setProperty(AWSConfigConstants.AWS_REGION, "eu-west-2");
+		return properties;
+	}
+
+}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/proxy/KinesisProxyV2FactoryTest.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static software.amazon.kinesis.connectors.flink.util.AWSUtil.AWS_CLIENT_CONFIG_PREFIX;
 
 /**
@@ -55,6 +57,27 @@ public class KinesisProxyV2FactoryTest {
 		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
 
 		assertEquals(12345, nettyConfiguration.connectTimeoutMillis());
+	}
+
+	@Test
+	public void testClientConfigurationPopulatedTcpKeepAliveDefaults() throws Exception {
+		Properties properties = properties();
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertTrue(nettyConfiguration.tcpKeepAlive());
+	}
+
+	@Test
+	public void testClientConfigurationPopulatedTcpKeepAliveFromProperties() throws Exception {
+		Properties properties = properties();
+		properties.setProperty(AWS_CLIENT_CONFIG_PREFIX + "useTcpKeepAlive", "false");
+
+		KinesisProxyV2Interface proxy = KinesisProxyV2Factory.createKinesisProxyV2(properties);
+		NettyConfiguration nettyConfiguration = getNettyConfiguration(proxy);
+
+		assertFalse(nettyConfiguration.tcpKeepAlive());
 	}
 
 	private NettyConfiguration getNettyConfiguration(final KinesisProxyV2Interface kinesis) throws Exception {


### PR DESCRIPTION
*Description of changes:*

Backporting changes from v2.2.0 to v1.x
* Refactor `requestRecords` to prevent AWS SDK/Netty threads blocking for EFO ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/40))
* Optionally populate ClientConfiguration from properties for EFO ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/41))
* Increasing read timeout to 6 minutes and enabling TCP keep alive for EFO ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/42))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
