### PR TITLE
FLINK-24431 Copy Flink connector changes to master

### DIFF
--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
@@ -29,8 +29,11 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFORegistrationType.EAGER;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
 import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.efoConsumerArn;
@@ -72,4 +75,22 @@ public class StreamConsumerRegistrarUtilTest {
 		verify(registrar).deregisterStreamConsumer("stream-2");
 	}
 
+	@Test
+	public void testDeregisterStreamConsumersOnlyDeregistersEFOLazilyInitializedConsumers() {
+		Properties configProps = getDefaultConfiguration();
+		configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		configProps.put(EFO_REGISTRATION_TYPE, EAGER.name());
+		List<String> streams = Arrays.asList("stream-1");
+		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
+
+		StreamConsumerRegistrarUtil.deregisterStreamConsumers(registrar, configProps, streams);
+
+		verifyZeroInteractions(registrar);
+	}
+
+	private Properties getDefaultConfiguration() {
+		Properties configProps = new Properties();
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
+		return configProps;
+	}
 }


### PR DESCRIPTION
*Issue #:* [FLINK-24431](https://issues.apache.org/jira/browse/FLINK-24431?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

*Description of changes:*
The EFO Kinesis connector will register and de-register stream consumers based on the configured registration strategy. When EAGER is used, the client (usually job manager) will register the consumer and then the task managers will de-register the consumer when job stops/fails. If the job is configured to restart on fail, then the consumer will not exist and the job will continuously fail over.

I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
