### PR TITLE
FLINK-24431 Copy Flink connector changes to release-1.0

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtil.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtil.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 
 import software.amazon.kinesis.connectors.flink.FlinkKinesisException;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.FanOutRecordPublisherConfiguration;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.StreamConsumerRegistrar;
 import software.amazon.kinesis.connectors.flink.proxy.FullJitterBackoff;
@@ -33,6 +32,12 @@ import software.amazon.kinesis.connectors.flink.proxy.KinesisProxyV2Interface;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
+
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.efoConsumerArn;
+import static software.amazon.kinesis.connectors.flink.util.AwsV2Util.isEagerEfoRegistrationType;
+import static software.amazon.kinesis.connectors.flink.util.AwsV2Util.isLazyEfoRegistrationType;
+import static software.amazon.kinesis.connectors.flink.util.AwsV2Util.isUsingEfoRecordPublisher;
 
 /**
  * A utility class that creates instances of {@link StreamConsumerRegistrar} and handles batch operations.
@@ -47,7 +52,7 @@ public class StreamConsumerRegistrarUtil {
 	 * @param streams the stream to register consumers against
 	 */
 	public static void eagerlyRegisterStreamConsumers(final Properties configProps, final List<String> streams) {
-		if (!AwsV2Util.isUsingEfoRecordPublisher(configProps) || !AwsV2Util.isEagerEfoRegistrationType(configProps)) {
+		if (!isUsingEfoRecordPublisher(configProps) || !isEagerEfoRegistrationType(configProps)) {
 			return;
 		}
 
@@ -61,7 +66,7 @@ public class StreamConsumerRegistrarUtil {
 	 * @param streams the stream to register consumers against
 	 */
 	public static void lazilyRegisterStreamConsumers(final Properties configProps, final List<String> streams) {
-		if (!AwsV2Util.isUsingEfoRecordPublisher(configProps) || !AwsV2Util.isLazyEfoRegistrationType(configProps)) {
+		if (!isUsingEfoRecordPublisher(configProps) || !isLazyEfoRegistrationType(configProps)) {
 			return;
 		}
 
@@ -69,23 +74,24 @@ public class StreamConsumerRegistrarUtil {
 	}
 
 	/**
-	 * Deregisters stream consumers for the given streams if EFO is enabled with EAGER|LAZY registration strategy.
+	 * Deregisters stream consumers for the given streams if EFO is enabled with LAZY registration strategy.
 	 *
 	 * @param configProps the properties to parse configuration from
 	 * @param streams the stream to register consumers against
 	 */
 	public static void deregisterStreamConsumers(final Properties configProps, final List<String> streams) {
-		if (!AwsV2Util.isUsingEfoRecordPublisher(configProps) || AwsV2Util.isNoneEfoRegistrationType(configProps)) {
-			return;
+		if (isConsumerDeregistrationRequired(configProps)) {
+			StreamConsumerRegistrar registrar = createStreamConsumerRegistrar(configProps, streams);
+			try {
+				deregisterStreamConsumers(registrar, configProps, streams);
+			} finally {
+				registrar.close();
+			}
 		}
+	}
 
-		StreamConsumerRegistrar registrar = createStreamConsumerRegistrar(configProps, streams);
-
-		try {
-			deregisterStreamConsumers(registrar, configProps, streams);
-		} finally {
-			registrar.close();
-		}
+	private static boolean isConsumerDeregistrationRequired(final Properties configProps) {
+		return isUsingEfoRecordPublisher(configProps) && isLazyEfoRegistrationType(configProps);
 	}
 
 	private static void registerStreamConsumers(final Properties configProps, final List<String> streams) {
@@ -103,12 +109,12 @@ public class StreamConsumerRegistrarUtil {
 			final StreamConsumerRegistrar registrar,
 			final Properties configProps,
 			final List<String> streams) {
-		String streamConsumerName = configProps.getProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME);
+		String streamConsumerName = configProps.getProperty(EFO_CONSUMER_NAME);
 
 		for (String stream : streams) {
 			try {
 				String streamConsumerArn = registrar.registerStreamConsumer(stream, streamConsumerName);
-				configProps.setProperty(ConsumerConfigConstants.efoConsumerArn(stream), streamConsumerArn);
+				configProps.setProperty(efoConsumerArn(stream), streamConsumerArn);
 			} catch (ExecutionException ex) {
 				throw new FlinkKinesisStreamConsumerRegistrarException("Error registering stream: " + stream, ex);
 			} catch (InterruptedException ex) {
@@ -123,18 +129,16 @@ public class StreamConsumerRegistrarUtil {
 			final StreamConsumerRegistrar registrar,
 			final Properties configProps,
 			final List<String> streams) {
-		if (!AwsV2Util.isUsingEfoRecordPublisher(configProps) || AwsV2Util.isNoneEfoRegistrationType(configProps)) {
-			return;
-		}
-
-		for (String stream : streams) {
-			try {
-				registrar.deregisterStreamConsumer(stream);
-			} catch (ExecutionException ex) {
-				throw new FlinkKinesisStreamConsumerRegistrarException("Error deregistering stream: " + stream, ex);
-			} catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
-				throw new FlinkKinesisStreamConsumerRegistrarException("Error registering stream: " + stream, ex);
+		if (isConsumerDeregistrationRequired(configProps)) {
+			for (String stream : streams) {
+				try {
+					registrar.deregisterStreamConsumer(stream);
+				} catch (ExecutionException ex) {
+					throw new FlinkKinesisStreamConsumerRegistrarException("Error deregistering stream: " + stream, ex);
+				} catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+					throw new FlinkKinesisStreamConsumerRegistrarException("Error registering stream: " + stream, ex);
+				}
 			}
 		}
 	}

--- a/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/util/StreamConsumerRegistrarUtilTest.java
@@ -20,7 +20,6 @@
 package software.amazon.kinesis.connectors.flink.util;
 
 import org.junit.Test;
-import software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants;
 import software.amazon.kinesis.connectors.flink.internals.publisher.fanout.StreamConsumerRegistrar;
 
 import java.util.Arrays;
@@ -30,7 +29,14 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFORegistrationType.EAGER;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static software.amazon.kinesis.connectors.flink.config.ConsumerConfigConstants.efoConsumerArn;
 
 /**
  * Tests for {@link StreamConsumerRegistrar}.
@@ -40,7 +46,7 @@ public class StreamConsumerRegistrarUtilTest {
 	@Test
 	public void testRegisterStreamConsumers() throws Exception {
 		Properties configProps = new Properties();
-		configProps.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "consumer-name");
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
 
 		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
 		when(registrar.registerStreamConsumer("stream-1", "consumer-name"))
@@ -50,15 +56,15 @@ public class StreamConsumerRegistrarUtilTest {
 
 		StreamConsumerRegistrarUtil.registerStreamConsumers(registrar, configProps, Arrays.asList("stream-1", "stream-2"));
 
-		assertEquals("stream-1-consumer-arn", configProps.getProperty(ConsumerConfigConstants.efoConsumerArn("stream-1")));
-		assertEquals("stream-2-consumer-arn", configProps.getProperty(ConsumerConfigConstants.efoConsumerArn("stream-2")));
+		assertEquals("stream-1-consumer-arn", configProps.getProperty(efoConsumerArn("stream-1")));
+		assertEquals("stream-2-consumer-arn", configProps.getProperty(efoConsumerArn("stream-2")));
 	}
 
 	@Test
 	public void testDeregisterStreamConsumersMissingStreamArn() throws Exception {
 		Properties configProps = new Properties();
-		configProps.setProperty(ConsumerConfigConstants.RECORD_PUBLISHER_TYPE, ConsumerConfigConstants.RecordPublisherType.EFO.name());
-		configProps.setProperty(ConsumerConfigConstants.EFO_CONSUMER_NAME, "consumer-name");
+		configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
 
 		List<String> streams = Arrays.asList("stream-1", "stream-2");
 		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
@@ -69,4 +75,22 @@ public class StreamConsumerRegistrarUtilTest {
 		verify(registrar).deregisterStreamConsumer("stream-2");
 	}
 
+	@Test
+	public void testDeregisterStreamConsumersOnlyDeregistersEFOLazilyInitializedConsumers() {
+		Properties configProps = getDefaultConfiguration();
+		configProps.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
+		configProps.put(EFO_REGISTRATION_TYPE, EAGER.name());
+		List<String> streams = Arrays.asList("stream-1");
+		StreamConsumerRegistrar registrar = mock(StreamConsumerRegistrar.class);
+
+		StreamConsumerRegistrarUtil.deregisterStreamConsumers(registrar, configProps, streams);
+
+		verifyZeroInteractions(registrar);
+	}
+
+	private Properties getDefaultConfiguration() {
+		Properties configProps = new Properties();
+		configProps.setProperty(EFO_CONSUMER_NAME, "consumer-name");
+		return configProps;
+	}
 }


### PR DESCRIPTION
*Issue #:* [FLINK-24431](https://issues.apache.org/jira/browse/FLINK-24431?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

*Description of changes:*
The EFO Kinesis connector will register and de-register stream consumers based on the configured registration strategy. When EAGER is used, the client (usually job manager) will register the consumer and then the task managers will de-register the consumer when job stops/fails. If the job is configured to restart on fail, then the consumer will not exist and the job will continuously fail over.

I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
