### PR TITLE
SequenceNumber class is not POJO type

### DIFF
--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestableFlinkKinesisConsumer.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/testutils/TestableFlinkKinesisConsumer.java
@@ -21,10 +21,7 @@ package software.amazon.kinesis.connectors.flink.testutils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
-
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
 
 import java.util.Properties;
@@ -42,21 +39,7 @@ public class TestableFlinkKinesisConsumer extends FlinkKinesisConsumer<String> {
 										final int indexOfThisConsumerSubtask) {
 		super(fakeStream, new SimpleStringSchema(), fakeConfiguration);
 
-		this.mockedRuntimeCtx = Mockito.mock(RuntimeContext.class);
-
-		Mockito.when(mockedRuntimeCtx.getNumberOfParallelSubtasks()).thenAnswer(new Answer<Integer>() {
-			@Override
-			public Integer answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return totalNumOfConsumerSubtasks;
-			}
-		});
-
-		Mockito.when(mockedRuntimeCtx.getIndexOfThisSubtask()).thenAnswer(new Answer<Integer>() {
-			@Override
-			public Integer answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return indexOfThisConsumerSubtask;
-			}
-		});
+		this.mockedRuntimeCtx = new MockStreamingRuntimeContext(true, totalNumOfConsumerSubtasks, indexOfThisConsumerSubtask);
 	}
 
 	@Override


### PR DESCRIPTION
*Issue* #47

SequenceNumber class is not POJO type

*Description of changes:*

This is a fix to address issues [FLINK-24549](https://issues.apache.org/jira/browse/FLINK-24549) and [FLINK-24943](https://issues.apache.org/jira/browse/FLINK-24943)

Since we can't just change API of SequenceNumber class to make it POJO, because it break backward compatibility, we would have to register Kryo Serializer for it explicitly to make disabling of Generic Types possible.

The changes are: 

1. Create createStateSerializer method that explicitly assigns KryoSrializer to SequenceNumber class and use this method to initialize state

2. Create unit test that checks for compatibility of previous TypeInformation based serializer and explicitly created KryoSerializer
