### PR TITLE
Bump Jackson version to 2.12.7 to address CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<flink.version>1.11.2</flink.version>
 		<guava.version>30.0-jre</guava.version>
-		<jackson2.version>2.12.1</jackson2.version>
+		<jackson2.version>2.12.7</jackson2.version>
 		<log4j.version>2.17.1</log4j.version>
 	</properties>
 


### PR DESCRIPTION
*Description of changes:*
Update Jackson version from 2.12.1 to 2.12.7 to address CVE-2020-36518.

Tested via unit tests and manual application using Polling and EFO consumers and producer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
