### PR TITLE
Bump Jackson version to 2.12.7 to address CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ under the License.
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
 		<guava.version>30.0-jre</guava.version>
-		<jackson2.version>2.12.1</jackson2.version>
+		<jackson2.version>2.12.7</jackson2.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
*Description of changes:*
Update Jackson version from 2.12.1 to 2.12.7 to address CVE-2020-36518.

Tested via unit tests and manual application using Polling and EFO consumers and producer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
