### PR TITLE
Update AWS Regions validation to allow for future AWS regions

### DIFF
--- a/src/main/java/software/amazon/kinesis/connectors/flink/util/AWSUtil.java
+++ b/src/main/java/software/amazon/kinesis/connectors/flink/util/AWSUtil.java
@@ -33,7 +33,6 @@ import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
@@ -54,6 +53,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Some utilities specific to Amazon Web Service.
@@ -213,12 +213,7 @@ public class AWSUtil {
 	 * @return true if the supplied region ID is valid, false otherwise
 	 */
 	public static boolean isValidRegion(String region) {
-		try {
-			Regions.fromName(region.toLowerCase());
-		} catch (IllegalArgumentException e) {
-			return false;
-		}
-		return true;
+		return Pattern.matches("^[a-z]+-([a-z]+[-]{0,1}[a-z]+-([0-9]|global)|global)$", region);
 	}
 
 	/**

--- a/src/test/java/software/amazon/kinesis/connectors/flink/util/AWSUtilTest.java
+++ b/src/test/java/software/amazon/kinesis/connectors/flink/util/AWSUtilTest.java
@@ -179,11 +179,16 @@ public class AWSUtilTest {
 	@Test
 	public void testValidRegion() {
 		assertTrue(AWSUtil.isValidRegion("us-east-1"));
+		assertTrue(AWSUtil.isValidRegion("us-gov-west-1"));
+		assertTrue(AWSUtil.isValidRegion("us-isob-east-1"));
+		assertTrue(AWSUtil.isValidRegion("aws-global"));
+		assertTrue(AWSUtil.isValidRegion("aws-iso-global"));
+		assertTrue(AWSUtil.isValidRegion("aws-iso-b-global"));
 	}
 
 	@Test
 	public void testInvalidRegion() {
-		assertFalse(AWSUtil.isValidRegion("ur-east-1"));
+		assertFalse(AWSUtil.isValidRegion("invalid-region"));
 	}
 
 	@Test


### PR DESCRIPTION
*Issue #, if available:* 
https://issues.apache.org/jira/browse/FLINK-28978

*Description of changes:*
Make the validation for AWS Region string passed into the Kinesis connector more permissive (checks that the shape of the string follows the general AWS Region shape, rather than validating that the Region exists in the Regions enum). This allows the Kinesis connector to cover future new AWS Regions as well.

This was cherry-picked from https://github.com/apache/flink/pull/20606


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
