### PR TITLE
Backport fixes for full compatibility with Flink 1.13

### DIFF
--- a/amazon-kinesis-connector-flink/pom.xml
+++ b/amazon-kinesis-connector-flink/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<parent>
 		<groupId>software.amazon.kinesis</groupId>
 		<artifactId>amazon-kinesis-connector-flink-parent</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/FlinkKinesisProducer.java
@@ -21,6 +21,7 @@ package software.amazon.kinesis.connectors.flink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
@@ -215,7 +216,10 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 
-		schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		schema.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 
 		// check and pass the configuration properties
 		KinesisProducerConfiguration producerConfig = KinesisConfigUtil.getValidatedProducerConfiguration(configProps);

--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/internals/KinesisDataFetcher.java
@@ -22,6 +22,7 @@ package software.amazon.kinesis.connectors.flink.internals;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -561,10 +562,15 @@ public class KinesisDataFetcher<T> {
 				StreamShardHandle streamShardHandle = subscribedShardsState.get(seededStateIndex)
 						.getStreamShardHandle();
 				KinesisDeserializationSchema<T> shardDeserializationSchema = getClonedDeserializationSchema();
-				shardDeserializationSchema.open(() -> consumerMetricGroup
-						.addGroup("subtaskId", String.valueOf(indexOfThisConsumerSubtask))
-						.addGroup("shardId", streamShardHandle.getShard().getShardId())
-						.addGroup("user"));
+				shardDeserializationSchema.open(
+						RuntimeContextInitializationContextAdapters.deserializationAdapter(
+								runtimeContext,
+								// ignore the provided metric group
+								metricGroup -> consumerMetricGroup
+										.addGroup("subtaskId", String.valueOf(indexOfThisConsumerSubtask))
+										.addGroup("shardId", streamShardHandle.getShard().getShardId())
+										.addGroup("user")
+						));
 				shardConsumersExecutor.submit(
 						createShardConsumer(
 								seededStateIndex,
@@ -670,10 +676,14 @@ public class KinesisDataFetcher<T> {
 
 				StreamShardHandle streamShardHandle = newShardState.getStreamShardHandle();
 				KinesisDeserializationSchema<T> shardDeserializationSchema = getClonedDeserializationSchema();
-				shardDeserializationSchema.open(() -> consumerMetricGroup
-						.addGroup("subtaskId", String.valueOf(indexOfThisConsumerSubtask))
-						.addGroup("shardId", streamShardHandle.getShard().getShardId())
-						.addGroup("user"));
+				shardDeserializationSchema.open(RuntimeContextInitializationContextAdapters.deserializationAdapter(
+						runtimeContext,
+						// ignore the provided metric group
+						metricGroup -> consumerMetricGroup
+								.addGroup("subtaskId", String.valueOf(indexOfThisConsumerSubtask))
+								.addGroup("shardId", streamShardHandle.getShard().getShardId())
+								.addGroup("user")
+				));
 				shardConsumersExecutor.submit(
 						createShardConsumer(
 								newStateIndex,

--- a/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitioner.java
+++ b/amazon-kinesis-connector-flink/src/main/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitioner.java
@@ -21,26 +21,22 @@
 package software.amazon.kinesis.connectors.flink.table;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.kinesis.connectors.flink.KinesisPartitioner;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -111,31 +107,32 @@ public final class RowDataFieldsKinesisPartitioner extends KinesisPartitioner<Ro
 	 */
 	private int fieldNamesStaticPrefixLength = 0;
 
-	public RowDataFieldsKinesisPartitioner(CatalogTable table) {
-		this(table, DEFAULT_DELIMITER);
+	public RowDataFieldsKinesisPartitioner(RowType physicalType, List<String> partitionKeys) {
+		this(physicalType, partitionKeys, DEFAULT_DELIMITER);
 	}
 
-	public RowDataFieldsKinesisPartitioner(CatalogTable table, String delimiter) {
-		Preconditions.checkNotNull(table, "table");
+	public RowDataFieldsKinesisPartitioner(
+			RowType physicalType, List<String> partitionKeys, String delimiter) {
+		Preconditions.checkNotNull(physicalType, "physicalType");
+		Preconditions.checkNotNull(partitionKeys, "partitionKeys");
 		Preconditions.checkNotNull(delimiter, "delimiter");
 		Preconditions.checkArgument(
-			table.isPartitioned(),
+			!partitionKeys.isEmpty(),
 			"Cannot create a RowDataFieldsKinesisPartitioner for a non-partitioned table");
 		Preconditions.checkArgument(
-			table.getPartitionKeys().size() == new HashSet<>(table.getPartitionKeys()).size(),
+			partitionKeys.size() == new HashSet<>(partitionKeys).size(),
 			"The sequence of partition keys cannot contain duplicates");
 
-		TableSchema schema = table.getSchema();
-		List<String> schemaFieldsList = Arrays.asList(schema.getFieldNames());
+		List<String> fieldsList = physicalType.getFieldNames();
 
 		List<String> badKeyNames = new ArrayList<>();
 		List<String> badKeyTypes = new ArrayList<>();
 
-		for (String fieldName : table.getPartitionKeys()) {
-			Optional<DataType> dataType = schema.getFieldDataType(fieldName);
-			if (!dataType.isPresent()) {
+		for (String fieldName : partitionKeys) {
+			int index = fieldsList.indexOf(fieldName);
+			if (index < 0) {
 				badKeyNames.add(fieldName);
-			} else if (!hasWellDefinedString(dataType.get().getLogicalType())) {
+			} else if (!hasWellDefinedString(physicalType.getTypeAt(index))) {
 				badKeyTypes.add(fieldName);
 			}
 		}
@@ -150,16 +147,13 @@ public final class RowDataFieldsKinesisPartitioner extends KinesisPartitioner<Ro
 			String.join(", ", badKeyTypes));
 
 		this.delimiter = delimiter;
-		this.fieldNames = table.getPartitionKeys();
+		this.fieldNames = partitionKeys;
 		this.dynamicFieldGetters = new HashMap<>();
-		for (String fieldName : table.getPartitionKeys()) {
-			TableColumn column = schema
-				.getTableColumn(fieldName)
-				.orElseThrow(() -> new RuntimeException("Unexpected field column " + fieldName));
+		for (String fieldName : partitionKeys) {
+			RowField field = physicalType.getFields().get(fieldsList.indexOf(fieldName));
 
-			RowData.FieldGetter fieldGetter = RowData.createFieldGetter(
-				column.getType().getLogicalType(),
-				schemaFieldsList.indexOf(column.getName()));
+			RowData.FieldGetter fieldGetter =
+					RowData.createFieldGetter(field.getType(), fieldsList.indexOf(field.getName()));
 
 			this.dynamicFieldGetters.put(fieldName, fieldGetter);
 		}
@@ -213,10 +207,10 @@ public final class RowDataFieldsKinesisPartitioner extends KinesisPartitioner<Ro
 	 * set of field names defined in {@link RowDataFieldsKinesisPartitioner#fieldNames}.
 	 *
 	 * @param candidateSubset A set of field names forming a candidate subset of
-	 *    {@link RowDataFieldsKinesisPartitioner#fieldNames}.
+	 *	{@link RowDataFieldsKinesisPartitioner#fieldNames}.
 	 *
 	 * @return true if and only if the {@code candidatePrefix} is a proper subset of
-	 *    {@link RowDataFieldsKinesisPartitioner#fieldNames}.
+	 *	{@link RowDataFieldsKinesisPartitioner#fieldNames}.
 	 */
 	private boolean isPartitionKeySubset(Set<String> candidateSubset) {
 		return new HashSet<>(fieldNames).containsAll(candidateSubset);

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
@@ -55,7 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.flink.util.CoreMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/KinesisDynamicTableFactoryTest.java
@@ -20,24 +20,24 @@
 
 package software.amazon.kinesis.connectors.flink.table;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.WatermarkSpec;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -47,7 +47,6 @@ import software.amazon.kinesis.connectors.flink.FlinkKinesisConsumer;
 import software.amazon.kinesis.connectors.flink.FlinkKinesisProducer;
 import software.amazon.kinesis.connectors.flink.RandomKinesisPartitioner;
 import software.amazon.kinesis.connectors.flink.testutils.TableOptionsBuilder;
-import software.amazon.kinesis.connectors.flink.testutils.TestFormatFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,6 +55,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -68,8 +69,6 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	private static final String STREAM_NAME = "myStream";
 
-	private static final String TABLE_NAME = "myTable";
-
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
@@ -79,12 +78,12 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testGoodTableSource() {
-		TableSchema sourceSchema = defaultSourceSchema().build();
+		ResolvedSchema sourceSchema = defaultSourceSchema();
 		Map<String, String> sourceOptions = defaultTableOptions().build();
-		CatalogTable catalogTable = createSourceTable(sourceSchema, sourceOptions);
 
 		// Construct actual DynamicTableSource using FactoryUtil
-		KinesisDynamicSource actualSource = actualDynamicSource(catalogTable);
+		KinesisDynamicSource actualSource =
+			(KinesisDynamicSource) createTableSource(sourceSchema, sourceOptions);
 
 		// Construct expected DynamicTableSink using factory under test
 		KinesisDynamicSource expectedSource = new KinesisDynamicSource(
@@ -109,21 +108,23 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testGoodTableSinkForPartitionedTable() {
-		TableSchema sinkSchema = defaultSinkSchema().build();
+		ResolvedSchema sinkSchema = defaultSinkSchema();
+		DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
 		Map<String, String> sinkOptions = defaultTableOptions().build();
 		List<String> sinkPartitionKeys = Arrays.asList("name", "curr_id");
-		CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions, sinkPartitionKeys);
 
 		// Construct actual DynamicTableSink using FactoryUtil
-		KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+		KinesisDynamicSink actualSink =
+			(KinesisDynamicSink) createTableSink(sinkSchema, sinkPartitionKeys, sinkOptions);
 
 		// Construct expected DynamicTableSink using factory under test
 		KinesisDynamicSink expectedSink = new KinesisDynamicSink(
-			sinkSchema.toPhysicalRowDataType(),
+			physicalDataType,
 			STREAM_NAME,
 			defaultProducerProperties(),
 			new TestFormatFactory.EncodingFormatMock(","),
-			new RowDataFieldsKinesisPartitioner(sinkTable));
+			new RowDataFieldsKinesisPartitioner(
+				(RowType) physicalDataType.getLogicalType(), sinkPartitionKeys));
 
 		// verify that the constructed DynamicTableSink is as expected
 		assertEquals(expectedSink, actualSink);
@@ -141,12 +142,12 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testGoodTableSinkForNonPartitionedTable() {
-		TableSchema sinkSchema = defaultSinkSchema().build();
+		ResolvedSchema sinkSchema = defaultSinkSchema();
 		Map<String, String> sinkOptions = defaultTableOptions().build();
-		CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions);
 
 		// Construct actual DynamicTableSink using FactoryUtil
-		KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+		KinesisDynamicSink actualSink =
+			(KinesisDynamicSink) createTableSink(sinkSchema, sinkOptions);
 
 		// Construct expected DynamicTableSink using factory under test
 		KinesisDynamicSink expectedSink = new KinesisDynamicSink(
@@ -176,7 +177,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testBadTableSinkForCustomPartitionerForPartitionedTable() {
-		TableSchema sinkSchema = defaultSinkSchema().build();
+		ResolvedSchema sinkSchema = defaultSinkSchema();
 		Map<String, String> sinkOptions = defaultTableOptions()
 			.withTableOption(KinesisOptions.SINK_PARTITIONER, "random")
 			.build();
@@ -187,12 +188,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 			KinesisOptions.SINK_PARTITIONER.key()))));
 
 		try {
-			FactoryUtil.createTableSink(
-				null,
-				ObjectIdentifier.of("default", "default", TABLE_NAME),
-				createSinkTable(sinkSchema, sinkOptions, Arrays.asList("name", "curr_id")),
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader());
+			createTableSink(sinkSchema, Arrays.asList("name", "curr_id"), sinkOptions);
 		} catch (ValidationException e) {
 			throw (ValidationException) e.getCause(); // unpack the causing exception
 		}
@@ -200,7 +196,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testBadTableSinkForNonExistingPartitionerClass() {
-		TableSchema sinkSchema = defaultSinkSchema().build();
+		ResolvedSchema sinkSchema = defaultSinkSchema();
 		Map<String, String> sinkOptions = defaultTableOptions()
 			.withTableOption(KinesisOptions.SINK_PARTITIONER, "abc")
 			.build();
@@ -209,58 +205,35 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 		thrown.expect(containsCause(new ValidationException(
 			"Could not find and instantiate partitioner class 'abc'")));
 
-		FactoryUtil.createTableSink(
-			null,
-			ObjectIdentifier.of("default", "default", TABLE_NAME),
-			createSinkTable(sinkSchema, sinkOptions, Collections.emptyList()),
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader());
+		createTableSink(sinkSchema, sinkOptions);
 	}
 
 	// --------------------------------------------------------------------------------------------
 	// Utilities
 	// --------------------------------------------------------------------------------------------
 
-	private CatalogTable createSourceTable(
-		TableSchema sourceSchema,
-		Map<String, String> sourceOptions) {
-		return createSourceTable(sourceSchema, sourceOptions, Collections.emptyList());
+	private ResolvedSchema defaultSourceSchema() {
+		return new ResolvedSchema(
+				Arrays.asList(
+						Column.physical("name", DataTypes.STRING()),
+						Column.physical("curr_id", DataTypes.BIGINT()),
+						Column.physical("time", DataTypes.TIMESTAMP(3)),
+						Column.computed(
+								"next_id",
+								ResolvedExpressionMock.of(DataTypes.BIGINT(), "curr_id + 1"))),
+				Collections.singletonList(
+						WatermarkSpec.of(
+								"time",
+								ResolvedExpressionMock.of(
+										DataTypes.TIMESTAMP(3), "time - INTERVAL '5' SECOND"))),
+				null);
 	}
 
-	private CatalogTable createSourceTable(
-		TableSchema sourceSchema,
-		Map<String, String> sourceOptions,
-		List<String> partitionKeys) {
-		return new CatalogTableImpl(sourceSchema, partitionKeys, sourceOptions, TABLE_NAME);
-	}
-
-	private CatalogTable createSinkTable(
-		TableSchema sinkSchema,
-		Map<String, String> sinkOptions) {
-		return createSinkTable(sinkSchema, sinkOptions, Collections.emptyList());
-	}
-
-	private CatalogTable createSinkTable(
-		TableSchema sinkSchema,
-		Map<String, String> sinkOptions,
-		List<String> partitionKeys) {
-		return new CatalogTableImpl(sinkSchema, partitionKeys, sinkOptions, TABLE_NAME);
-	}
-
-	private TableSchema.Builder defaultSourceSchema() {
-		return TableSchema.builder()
-			.add(TableColumn.of("name", DataTypes.STRING()))
-			.add(TableColumn.of("curr_id", DataTypes.BIGINT()))
-			.add(TableColumn.of("time", DataTypes.TIMESTAMP(3)))
-			.add(TableColumn.of("next_id", DataTypes.BIGINT(), "curr_id + 1"))
-			.watermark("time", "time" + " - INTERVAL '5' SECOND", DataTypes.TIMESTAMP(3));
-	}
-
-	private TableSchema.Builder defaultSinkSchema() {
-		return TableSchema.builder()
-			.add(TableColumn.of("name", DataTypes.STRING()))
-			.add(TableColumn.of("curr_id", DataTypes.BIGINT()))
-			.add(TableColumn.of("time", DataTypes.TIMESTAMP(3)));
+	private ResolvedSchema defaultSinkSchema() {
+		return ResolvedSchema.of(
+				Column.physical("name", DataTypes.STRING()),
+				Column.physical("curr_id", DataTypes.BIGINT()),
+				Column.physical("time", DataTypes.TIMESTAMP(3)));
 	}
 
 	private TableOptionsBuilder defaultTableOptions() {
@@ -302,25 +275,6 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 			setProperty("aws.credentials.provider.basic.secretkey", "SuperSecretSecretSquirrel");
 			setProperty("CollectionMaxCount", "100");
 		}};
-	}
-
-	private KinesisDynamicSource actualDynamicSource(CatalogTable catalogTable) {
-		return (KinesisDynamicSource)
-			FactoryUtil.createTableSource(
-				null,
-				ObjectIdentifier.of("default", "default", TABLE_NAME),
-				catalogTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader());
-	}
-
-	private KinesisDynamicSink actualDynamicSink(CatalogTable catalogTable) {
-		return (KinesisDynamicSink) FactoryUtil.createTableSink(
-			null,
-			ObjectIdentifier.of("default", "default", TABLE_NAME),
-			catalogTable,
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader());
 	}
 
 	private <T> T as(Object object, Class<T> clazz) {

--- a/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitionerTest.java
+++ b/amazon-kinesis-connector-flink/src/test/java/software/amazon/kinesis/connectors/flink/table/RowDataFieldsKinesisPartitionerTest.java
@@ -45,8 +45,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.table.utils.EncodingUtils.repeat;
-import static org.apache.flink.util.CoreMatchers.containsCause;
 import static org.junit.Assert.assertEquals;
 import static software.amazon.kinesis.connectors.flink.table.RowDataFieldsKinesisPartitioner.MAX_PARTITION_KEY_LENGTH;
 

--- a/amazon-kinesis-sql-connector-flink/pom.xml
+++ b/amazon-kinesis-sql-connector-flink/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<parent>
 		<groupId>software.amazon.kinesis</groupId>
 		<artifactId>amazon-kinesis-connector-flink-parent</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ under the License.
 
 	<groupId>software.amazon.kinesis</groupId>
 	<artifactId>amazon-kinesis-connector-flink-parent</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Amazon Kinesis Connector for Apache Flink Parent</name>
 
@@ -47,7 +47,7 @@ under the License.
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
-		<flink.version>1.11.2</flink.version>
+		<flink.version>1.13.6</flink.version>
 		<guava.version>30.0-jre</guava.version>
 		<jackson2.version>2.13.4</jackson2.version>
 		<jackson-databind.version>2.13.4.2</jackson-databind.version>


### PR DESCRIPTION
Backport the following fixes  from Apache Flink 1.13.6 release

- [[FLINK-18363] Add user classloader to context in DeSerializationSchema](https://github.com/apache/flink/commit/da67eeb90dda7d6610c5328f061ab417a5c4edbc)
- [[FLINK-21913][table][connectors] Update DynamicTableFactory.Context](https://github.com/apache/flink/commit/73338e22bd0567169ce2636c8f9e3b87df783385)
- [[hotfix][tests] Move containsCause to FlinkMatchers](https://github.com/apache/flink/commit/7ea887f86e96cc10eb461b73b9d0761b5720bc8a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
